### PR TITLE
Add handling for if the user ends the session by timing out

### DIFF
--- a/vaccine/application.py
+++ b/vaccine/application.py
@@ -20,6 +20,23 @@ class Application:
         """
         Processes the message, and returns a list of messages to return to the user
         """
+        if message.session_event == Message.SESSION_EVENT.CLOSE:
+            self.user.in_session = False
+            return [
+                message.reply(
+                    content="\n".join(
+                        [
+                            "We're sorry, but you've taken too long to reply and your "
+                            "session has expired.",
+                            "If you would like to continue, you can at anytime by "
+                            "typing the word *VACCINE*.",
+                            "",
+                            "Reply *MENU* to return to the main menu",
+                        ]
+                    ),
+                    continue_session=False,
+                )
+            ]
         state = await self.get_current_state()
         if self.user.in_session:
             return await state.process_message(message)

--- a/vaccine/tests/test_application.py
+++ b/vaccine/tests/test_application.py
@@ -163,3 +163,33 @@ async def test_age_invalid():
         "represents your age in years"
     )
     assert "state_age" not in u.answers
+
+
+@pytest.mark.asyncio
+async def test_user_end_sesssion():
+    """
+    If the user has ended the session, then we should send them the session end message
+    """
+    u = User(
+        addr="27820001001", state=StateData(name="state_occupation"), in_session=True
+    )
+    app = Application(u)
+    msg = Message(
+        to_addr="27820001002",
+        from_addr="27820001002",
+        transport_name="whatsapp",
+        transport_type=Message.TRANSPORT_TYPE.HTTP_API,
+        session_event=Message.SESSION_EVENT.CLOSE,
+    )
+    [reply] = await app.process_message(msg)
+    assert u.in_session is False
+    assert reply.content == "\n".join(
+        [
+            "We're sorry, but you've taken too long to reply and your session has "
+            "expired.",
+            "If you would like to continue, you can at anytime by typing the word "
+            "*VACCINE*.",
+            "",
+            "Reply *MENU* to return to the main menu",
+        ]
+    )


### PR DESCRIPTION
If the user times out in the Turn conversation claim, the transport will send us a session close message. We should reply to this message letting the user know that they've timed out, and how to get back in