### PR TITLE
Add reset keyword

### DIFF
--- a/vaccine/base_application.py
+++ b/vaccine/base_application.py
@@ -44,6 +44,10 @@ class BaseApplication:
         Processes the message, and returns a list of messages to return to the user
         """
         self.inbound = message
+        if message.content == "!reset":
+            self.user.state.name = self.START_STATE
+            self.user.answers = {}
+            self.user.session_id = None
         state = await self.get_current_state()
         if self.user.session_id is not None:
             await state.process_message(message)

--- a/vaccine/base_application.py
+++ b/vaccine/base_application.py
@@ -11,6 +11,8 @@ STATE_CHANGE = Counter(
 
 
 class BaseApplication:
+    START_STATE = "state_start"
+
     def __init__(self, user: User):
         self.user = user
         self.answer_events: List[Answer] = []

--- a/vaccine/base_application.py
+++ b/vaccine/base_application.py
@@ -45,7 +45,7 @@ class BaseApplication:
         """
         self.inbound = message
         if message.content == "!reset":
-            self.user.state.name = self.START_STATE
+            self.state_name = self.START_STATE
             self.user.answers = {}
             self.user.session_id = None
         state = await self.get_current_state()

--- a/vaccine/tests/test_vaccine_eligibility.py
+++ b/vaccine/tests/test_vaccine_eligibility.py
@@ -702,3 +702,28 @@ async def test_user_end_sesssion():
             "Reply *MENU* to return to the main menu",
         ]
     )
+
+
+@pytest.mark.asyncio
+async def test_reset_keyword():
+    """
+    The reset keyword should reset all state and start the user from the beginning
+    """
+    u = User(
+        addr="27820001001",
+        state=StateData(name="state_occupation"),
+        session_id="1",
+        answers={"test": "answers"},
+    )
+    app = Application(u)
+    msg = Message(
+        content="!reset",
+        to_addr="27820001002",
+        from_addr="27820001002",
+        transport_name="whatsapp",
+        transport_type=Message.TRANSPORT_TYPE.HTTP_API,
+    )
+    await app.process_message(msg)
+    assert u.session_id != "1"
+    assert u.answers == {}
+    assert u.state.name == "state_occupation"


### PR DESCRIPTION
This adds a hidden `!reset` keyword to the framework.

This allows you for all apps, to send in a message with `!reset`, to reset the user's state and put them in the beginning of the flow.

This is very useful for quick testing and QA of the system.