### PR TITLE
Better session handling

### DIFF
--- a/vaccine/base_application.py
+++ b/vaccine/base_application.py
@@ -51,11 +51,14 @@ class BaseApplication:
             self.user.answers = {}
             self.user.session_id = None
         state = await self.get_current_state()
-        if self.user.session_id is not None:
-            await state.process_message(message)
-        else:
+        if (
+            message.session_event == Message.SESSION_EVENT.NEW
+            or self.user.session_id is None
+        ):
             self.user.session_id = random_id()
             await state.display(message)
+        else:
+            await state.process_message(message)
         return self.messages
 
     def save_answer(self, name: str, value: Any):

--- a/vaccine/states.py
+++ b/vaccine/states.py
@@ -7,9 +7,11 @@ from vaccine.models import Message
 
 
 class EndState:
-    def __init__(self, app: BaseApplication, text: str, next: str):
+    def __init__(self, app: BaseApplication, text: str, next: Optional[str] = None):
         self.app = app
         self.text = text
+        if next is None:
+            next = app.START_STATE
         self.next = next
 
     async def process_message(self, message: Message) -> List[Message]:

--- a/vaccine/states.py
+++ b/vaccine/states.py
@@ -7,16 +7,23 @@ from vaccine.models import Message
 
 
 class EndState:
-    def __init__(self, app: BaseApplication, text: str, next: Optional[str] = None):
+    def __init__(
+        self,
+        app: BaseApplication,
+        text: str,
+        next: Optional[str] = None,
+        clear_state: bool = True,
+    ):
         self.app = app
         self.text = text
-        if next is None:
-            next = app.START_STATE
         self.next = next
+        self.clear_state = clear_state
 
     async def process_message(self, message: Message) -> List[Message]:
         self.app.user.session_id = None
         self.app.state_name = self.next
+        if self.clear_state:
+            self.app.user.answers = {}
         return self.app.send_message(self.text, continue_session=False)
 
     async def display(self, message: Message) -> List[Message]:

--- a/vaccine/tests/test_vaccine_eligibility.py
+++ b/vaccine/tests/test_vaccine_eligibility.py
@@ -344,7 +344,7 @@ async def test_location_pin():
 @pytest.mark.asyncio
 async def test_comorbidities_valid():
     """
-    A valid response should save the answer and go to the next stage
+    A valid response should finish the questionairre
     """
     u = User(
         addr="27820001001",
@@ -363,7 +363,6 @@ async def test_comorbidities_valid():
     await app.process_message(msg)
     assert u.state.name == "state_start"
     assert u.session_id is None
-    assert u.answers["state_comorbidities"] == "yes"
 
 
 @pytest.mark.asyncio
@@ -617,7 +616,8 @@ async def test_result_3():
 @pytest.mark.asyncio
 async def test_confirm_notification_yes():
     """
-    If the user selects to get a notification, should save and display result to user
+    If the user selects to get a notification, should display result to user and end
+    session
     """
     u = User(addr="27820001001", state=StateData(name="state_result_2"), session_id="1")
     app = Application(u)
@@ -641,13 +641,12 @@ async def test_confirm_notification_yes():
     )
     assert u.state.name == "state_start"
     assert u.session_id is None
-    assert u.answers["state_result_2"] == "yes"
 
 
 @pytest.mark.asyncio
 async def test_confirm_notification_no():
     """
-    If the user selects to not get a notification, should save and display result
+    If the user selects to not get a notification, should display result and end session
     """
     u = User(addr="27820001001", state=StateData(name="state_result_3"), session_id="1")
     app = Application(u)
@@ -671,7 +670,6 @@ async def test_confirm_notification_no():
     )
     assert u.state.name == "state_start"
     assert u.session_id is None
-    assert u.answers["state_result_3"] == "no"
 
 
 @pytest.mark.asyncio

--- a/vaccine/tests/test_vaccine_reg_ussd.py
+++ b/vaccine/tests/test_vaccine_reg_ussd.py
@@ -140,8 +140,6 @@ async def test_under_age_notification_confirm():
     [reply] = await app.process_message(msg)
     assert len(reply.content) < 160
     assert reply.content == "Thank you for confirming"
-    assert u.answers["state_under_age_notification"] == "yes"
-    assert u.state.name == "state_age_gate"
     assert reply.session_event == Message.SESSION_EVENT.CLOSE
 
 
@@ -1013,11 +1011,7 @@ async def test_medical_aid_invalid():
 
 @pytest.mark.asyncio
 async def test_terms_and_conditions():
-    u = User(
-        addr="27820001001",
-        state=StateData(name="state_age_gate"),
-        session_id=1,
-    )
+    u = User(addr="27820001001", state=StateData(name="state_age_gate"), session_id=1)
     app = Application(u)
     msg = Message(
         content="yes",
@@ -1167,7 +1161,6 @@ async def test_state_success(evds_mock):
         "information and appointment details will be sent via SMS."
     )
     assert reply.session_event == Message.SESSION_EVENT.CLOSE
-    assert u.state.name == "state_age_gate"
 
     [requests] = evds_mock.app.requests
     assert requests.json == {
@@ -1229,7 +1222,6 @@ async def test_state_success_temporary_failure(evds_mock):
         "information and appointment details will be sent via SMS."
     )
     assert reply.session_event == Message.SESSION_EVENT.CLOSE
-    assert u.state.name == "state_age_gate"
 
     requests = evds_mock.app.requests
     assert len(requests) == 2
@@ -1292,7 +1284,6 @@ async def test_state_error(evds_mock):
         "not able to be processed. Please try again later"
     )
     assert reply.session_event == Message.SESSION_EVENT.CLOSE
-    assert u.state.name == "state_age_gate"
 
     requests = evds_mock.app.requests
     assert len(requests) == 3

--- a/vaccine/vaccine_reg_ussd.py
+++ b/vaccine/vaccine_reg_ussd.py
@@ -114,7 +114,7 @@ class Application(BaseApplication):
         )
 
     async def state_confirm_notification(self):
-        return EndState(self, text="Thank you for confirming", next=self.START_STATE)
+        return EndState(self, text="Thank you for confirming")
 
     async def state_terms_and_conditions(self):
         return MenuState(
@@ -531,7 +531,6 @@ class Application(BaseApplication):
             self,
             text=":) You have SUCCESSFULLY registered to get vaccinated. Additional "
             "information and appointment details will be sent via SMS.",
-            next=self.START_STATE,
         )
 
     async def state_error(self):
@@ -539,5 +538,4 @@ class Application(BaseApplication):
             self,
             text="Something went wrong with your registration session. Your "
             "registration was not able to be processed. Please try again later",
-            next=self.START_STATE,
         )

--- a/vaccine/vaccine_reg_ussd.py
+++ b/vaccine/vaccine_reg_ussd.py
@@ -62,7 +62,6 @@ class Application(BaseApplication):
             and self.state_name is not None
             and self.state_name != self.START_STATE
         ):
-            self.user.session_id = None
             self.save_answer("resume_state", self.state_name)
             self.state_name = "state_timed_out"
         return await super().process_message(message)


### PR DESCRIPTION
This PR combines a few improvements to the way that we're handling sessions:
1. Previously, on a new session, we should call `process_message`, which would return the error message of the state. We now call `display`
2. Default the `next` of `EndState` to the start state, this is almost always what we want
3. Have the `EndState` clear answers by default. Most of the time we clear the user's answers at the beginning so that we can start from fresh, so we might as well clear it at the session end so that it's not taking up space in Redis. Having it default to clear makes sense as this is what we want most of the time