### PR TITLE
Remove refugee validation and extraction

### DIFF
--- a/vaccine/vaccine_reg_ussd.py
+++ b/vaccine/vaccine_reg_ussd.py
@@ -215,10 +215,7 @@ class Application(BaseApplication):
                 )
 
             idtype = self.user.answers["state_identification_type"]
-            if (
-                idtype == self.ID_TYPES.rsa_id.value
-                or idtype == self.ID_TYPES.refugee.value
-            ):
+            if idtype == self.ID_TYPES.rsa_id.value:
                 idno = self.user.answers["state_identification_number"]
                 if value[-2:] != idno[:2]:
                     raise ErrorMessage(

--- a/vaccine/vaccine_reg_ussd.py
+++ b/vaccine/vaccine_reg_ussd.py
@@ -145,7 +145,7 @@ class Application(BaseApplication):
             next_state = "state_gender"
 
         async def validate_identification_number(value):
-            if idtype == self.ID_TYPES.rsa_id or idtype == self.ID_TYPES.refugee:
+            if idtype == self.ID_TYPES.rsa_id:
                 try:
                     id_number = SAIDNumber(value)
                     dob = id_number.date_of_birth

--- a/vaccine/vaccine_reg_whatsapp.py
+++ b/vaccine/vaccine_reg_whatsapp.py
@@ -293,7 +293,7 @@ class Application(BaseApplication):
             next_state = "state_first_name"
 
         async def validate_identification_number(value):
-            if idtype == self.ID_TYPES.rsa_id or idtype == self.ID_TYPES.refugee:
+            if idtype == self.ID_TYPES.rsa_id:
                 try:
                     id_number = SAIDNumber(value)
                     dob = id_number.date_of_birth
@@ -383,10 +383,7 @@ class Application(BaseApplication):
                 )
 
             idtype = self.user.answers["state_identification_type"]
-            if (
-                idtype == self.ID_TYPES.rsa_id.value
-                or idtype == self.ID_TYPES.refugee.value
-            ):
+            if idtype == self.ID_TYPES.rsa_id.value:
                 idno = self.user.answers["state_identification_number"]
                 if value[-2:] != idno[:2]:
                     raise ErrorMessage(


### PR DESCRIPTION
There should be no validation on the refugee field, to allow for external refugee numbers