### PR TITLE
Add exit keyword handling

### DIFF
--- a/vaccine/tests/test_vaccine_reg_whatsapp.py
+++ b/vaccine/tests/test_vaccine_reg_whatsapp.py
@@ -1735,3 +1735,24 @@ async def test_throttle():
     )
 
     config.THROTTLE_PERCENTAGE = throttle
+
+
+@pytest.mark.asyncio
+async def test_exit_keywords():
+    u = User(
+        addr="27820001001",
+        state=StateData(name="state_terms_and_conditions_summary"),
+        session_id=1,
+    )
+    app = Application(u)
+    msg = Message(
+        content="menu",
+        to_addr="27820001002",
+        from_addr="27820001001",
+        transport_name="whatsapp",
+        transport_type=Message.TRANSPORT_TYPE.HTTP_API,
+    )
+    [reply] = await app.process_message(msg)
+    assert reply.content is None
+    assert reply.session_event == Message.SESSION_EVENT.CLOSE
+    assert reply.helper_metadata["automation_handle"]

--- a/vaccine/vaccine_reg_whatsapp.py
+++ b/vaccine/vaccine_reg_whatsapp.py
@@ -1,5 +1,6 @@
 import logging
 import random
+import re
 from datetime import date
 from email.utils import parseaddr
 from enum import Enum
@@ -79,6 +80,15 @@ class Application(BaseApplication):
     async def process_message(self, message: Message) -> List[Message]:
         if message.session_event == Message.SESSION_EVENT.CLOSE:
             self.state_name = "state_timeout"
+        if re.sub(r"\W+", " ", message.content or "").strip().lower() in {"menu", "0"}:
+            return [
+                message.reply(
+                    None,
+                    continue_session=False,
+                    helper_metadata={"automation_handle": True},
+                )
+            ]
+
         return await super().process_message(message)
 
     async def state_timeout(self):


### PR DESCRIPTION
This allows our WhatsApp users to send in one of the exit keywords anywhere in the flow, to exit the flow and return to the main app