### PR TITLE
Clear state on exit keywords

### DIFF
--- a/vaccine/states.py
+++ b/vaccine/states.py
@@ -14,18 +14,23 @@ class EndState:
         text: str,
         next: Optional[str] = None,
         clear_state: bool = True,
+        helper_metadata: Optional[dict] = None,
     ):
         self.app = app
         self.text = text
         self.next = next
         self.clear_state = clear_state
+        self.helper_metadata = helper_metadata
 
     async def process_message(self, message: Message) -> List[Message]:
         self.app.user.session_id = None
         self.app.state_name = self.next
         if self.clear_state:
             self.app.user.answers = {}
-        return self.app.send_message(self.text, continue_session=False)
+        kwargs = {"content": self.text, "continue_session": False}
+        if self.helper_metadata is not None:
+            kwargs["helper_metadata"] = self.helper_metadata
+        return self.app.send_message(**kwargs)
 
     async def display(self, message: Message) -> List[Message]:
         return await self.process_message(message)

--- a/vaccine/tests/test_vaccine_reg_whatsapp.py
+++ b/vaccine/tests/test_vaccine_reg_whatsapp.py
@@ -1753,6 +1753,8 @@ async def test_exit_keywords():
         transport_type=Message.TRANSPORT_TYPE.HTTP_API,
     )
     [reply] = await app.process_message(msg)
-    assert reply.content is None
+    assert reply.content == ""
     assert reply.session_event == Message.SESSION_EVENT.CLOSE
-    assert reply.helper_metadata["automation_handle"]
+    assert reply.helper_metadata["automation_handle"] is True
+    assert u.answers == {}
+    assert u.state.name is None

--- a/vaccine/vaccine_reg_whatsapp.py
+++ b/vaccine/vaccine_reg_whatsapp.py
@@ -81,13 +81,7 @@ class Application(BaseApplication):
         if message.session_event == Message.SESSION_EVENT.CLOSE:
             self.state_name = "state_timeout"
         if re.sub(r"\W+", " ", message.content or "").strip().lower() in {"menu", "0"}:
-            return [
-                message.reply(
-                    None,
-                    continue_session=False,
-                    helper_metadata={"automation_handle": True},
-                )
-            ]
+            self.state_name = "state_exit"
 
         return await super().process_message(message)
 
@@ -108,6 +102,9 @@ class Application(BaseApplication):
                 ]
             ),
         )
+
+    async def state_exit(self):
+        return EndState(self, "", helper_metadata={"automation_handle": True})
 
     async def state_age_gate(self):
         self.user.answers = {}


### PR DESCRIPTION
If we don't then when the user uses the keyword to enter the flow again, that message will be processed by whatever state they were on when they left