### PR TITLE
Application error handling

### DIFF
--- a/vaccine/states.py
+++ b/vaccine/states.py
@@ -1,16 +1,18 @@
 from dataclasses import dataclass
 from inspect import iscoroutinefunction
-from typing import Awaitable, Callable, List, Optional, Union
+from typing import TYPE_CHECKING, Awaitable, Callable, List, Optional, Union
 
-from vaccine.base_application import BaseApplication
 from vaccine.models import Message
 from vaccine.utils import get_display_choices
+
+if TYPE_CHECKING:  # pragma: no cover
+    from vaccine.base_application import BaseApplication
 
 
 class EndState:
     def __init__(
         self,
-        app: BaseApplication,
+        app: "BaseApplication",
         text: str,
         next: Optional[str] = None,
         clear_state: bool = True,
@@ -45,7 +47,7 @@ class Choice:
 class ChoiceState:
     def __init__(
         self,
-        app: BaseApplication,
+        app: "BaseApplication",
         question: str,
         choices: List[Choice],
         error: str,
@@ -100,7 +102,7 @@ class ChoiceState:
 class MenuState(ChoiceState):
     def __init__(
         self,
-        app: BaseApplication,
+        app: "BaseApplication",
         question: str,
         choices: List[Choice],
         error: str,
@@ -126,7 +128,7 @@ class ErrorMessage(Exception):
 class FreeText:
     def __init__(
         self,
-        app: BaseApplication,
+        app: "BaseApplication",
         question: str,
         next: str,
         check: Optional[Callable[[Optional[str]], Awaitable]] = None,

--- a/vaccine/tests/test_healthcheck_vacreg_ussd.py
+++ b/vaccine/tests/test_healthcheck_vacreg_ussd.py
@@ -12,7 +12,7 @@ from vaccine.vaccine_reg_ussd import Application as VacRegApp
 def test_no_state_name_clashes():
     hc_states = set(s for s in dir(HealthCheckApp) if s.startswith("state_"))
     vr_states = set(s for s in dir(VacRegApp) if s.startswith("state_"))
-    intersection = (hc_states & vr_states) - {"state_name"}
+    intersection = (hc_states & vr_states) - {"state_name", "state_error"}
     assert len(intersection) == 0, f"Common states to both apps: {intersection}"
 
 

--- a/vaccine/tests/test_vaccine_reg_whatsapp.py
+++ b/vaccine/tests/test_vaccine_reg_whatsapp.py
@@ -1754,3 +1754,23 @@ async def test_exit_keywords():
     assert reply.helper_metadata["automation_handle"] is True
     assert u.answers == {}
     assert u.state.name is None
+
+
+@pytest.mark.asyncio
+async def test_uncaught_exception():
+    u = User(
+        addr="27820001001", state=StateData(name="state_vaccination_time"), session_id=1
+    )
+    app = Application(u)
+    msg = Message(
+        content="1",
+        to_addr="27820001002",
+        from_addr="27820001001",
+        transport_name="whatsapp",
+        transport_type=Message.TRANSPORT_TYPE.HTTP_API,
+    )
+    [reply] = await app.process_message(msg)
+    assert reply.content == "Something went wrong. Please try again later."
+    assert reply.session_event == Message.SESSION_EVENT.CLOSE
+    assert u.answers == {}
+    assert u.state.name is None


### PR DESCRIPTION
If there is an uncaught error in the application, we should log it so that we get an alert in sentry, and then show the user an error message, instead of just crashing and showing nothing to the user