### PR TITLE
Medical aid copy update, and go to yes/no on other

### DIFF
--- a/vaccine/tests/test_vaccine_reg_whatsapp.py
+++ b/vaccine/tests/test_vaccine_reg_whatsapp.py
@@ -1176,7 +1176,7 @@ async def test_medical_aid_list_other(evds_mock):
         transport_type=Message.TRANSPORT_TYPE.HTTP_API,
     )
     [reply] = await app.process_message(msg)
-    assert u.state.name == "state_medical_aid_search"
+    assert u.state.name == "state_medical_aid"
 
 
 @pytest.mark.asyncio

--- a/vaccine/vaccine_reg_whatsapp.py
+++ b/vaccine/vaccine_reg_whatsapp.py
@@ -753,7 +753,7 @@ class Application(BaseApplication):
                 [
                     "*VACCINE REGISTRATION SECURE CHAT* 🔐",
                     "",
-                    "Do you belong to a Medical Aid?",
+                    "Do you belong to a South African Medical Aid?",
                 ]
             ),
             choices=[
@@ -786,7 +786,7 @@ class Application(BaseApplication):
     async def state_medical_aid_list(self):
         async def next_state(choice: Choice):
             if choice.value == "other":
-                return "state_medical_aid_search"
+                return "state_medical_aid"
             return "state_medical_aid_number"
 
         search = self.user.answers["state_medical_aid_search"] or ""


### PR DESCRIPTION
Updates the medical aid copy to refer to south african medical aids, and on selecting "Other" goes back to the medical aid yes/no question, so that the user can rather choose no medical aid if they realise that they don't have a south african medical aid.