### PR TITLE
Strip whitespace from SA ID number

### DIFF
--- a/vaccine/tests/test_vaccine_reg_ussd.py
+++ b/vaccine/tests/test_vaccine_reg_ussd.py
@@ -1367,7 +1367,7 @@ async def test_state_success(evds_mock, eventstore_mock):
             "state_surname": "test surname",
             "state_first_name": "test first name",
             "state_identification_type": "rsa_id",
-            "state_identification_number": "6001010001081",
+            "state_identification_number": " 6001010001081  ",
         },
     )
     app = Application(u)

--- a/vaccine/tests/test_vaccine_reg_whatsapp.py
+++ b/vaccine/tests/test_vaccine_reg_whatsapp.py
@@ -1415,7 +1415,7 @@ async def test_state_success(evds_mock, eventstore_mock):
             "state_surname": "test surname",
             "state_first_name": "test first name",
             "state_identification_type": "rsa_id",
-            "state_identification_number": "6001010001081",
+            "state_identification_number": " 6001010001081 ",
             "state_medical_aid": "state_vaccination_time",
             "state_email_address": "SKIP",
         },

--- a/vaccine/vaccine_reg_ussd.py
+++ b/vaccine/vaccine_reg_ussd.py
@@ -576,7 +576,7 @@ class Application(BaseApplication):
         }
         id_type = self.user.answers["state_identification_type"]
         if id_type == self.ID_TYPES.rsa_id.name:
-            data["iDNumber"] = self.user.answers["state_identification_number"]
+            data["iDNumber"] = self.user.answers["state_identification_number"].strip()
         if (
             id_type == self.ID_TYPES.refugee.name
             or id_type == self.ID_TYPES.asylum_seeker.name
@@ -649,7 +649,7 @@ class Application(BaseApplication):
         }
         id_type = self.user.answers["state_identification_type"]
         if id_type == self.ID_TYPES.rsa_id.name:
-            data["id_number"] = self.user.answers["state_identification_number"]
+            data["id_number"] = self.user.answers["state_identification_number"].strip()
         if id_type == self.ID_TYPES.asylum_seeker.name:
             data["asylum_seeker_number"] = self.user.answers[
                 "state_identification_number"

--- a/vaccine/vaccine_reg_whatsapp.py
+++ b/vaccine/vaccine_reg_whatsapp.py
@@ -930,7 +930,7 @@ class Application(BaseApplication):
         }
         id_type = self.user.answers["state_identification_type"]
         if id_type == self.ID_TYPES.rsa_id.name:
-            data["iDNumber"] = self.user.answers["state_identification_number"]
+            data["iDNumber"] = self.user.answers["state_identification_number"].strip()
         if (
             id_type == self.ID_TYPES.refugee.name
             or id_type == self.ID_TYPES.asylum_seeker.name
@@ -1010,7 +1010,7 @@ class Application(BaseApplication):
         }
         id_type = self.user.answers["state_identification_type"]
         if id_type == self.ID_TYPES.rsa_id.name:
-            data["id_number"] = self.user.answers["state_identification_number"]
+            data["id_number"] = self.user.answers["state_identification_number"].strip()
         if id_type == self.ID_TYPES.asylum_seeker.name:
             data["asylum_seeker_number"] = self.user.answers[
                 "state_identification_number"


### PR DESCRIPTION
The ID number validation on EVDS fails if there is leading or trailing whitespace, so remove that before we submit