### PR TITLE
Ask a Question UX improvements

### DIFF
--- a/vaccine/ask_a_question.py
+++ b/vaccine/ask_a_question.py
@@ -75,10 +75,10 @@ class Application(BaseApplication):
 
     async def state_question(self):
         question = self._(
-            "❓ *YOUR VACCINE QUESTIONS*\n"
+            "❓ *ASK*  your questions about vaccines\n"
             "\n"
-            "Search our knowledge hub by *typing your own question* or sharing a "
-            "'*rumour*' that's going around to get the facts!\n"
+            "Try *typing your own question* or sharing/forwarding a '*rumour*' that's "
+            "going around to get the facts!\n"
             "\n"
             '[💡Tip: Reply with a question like: "_Are vaccines safe?"_]'
         )

--- a/vaccine/ask_a_question.py
+++ b/vaccine/ask_a_question.py
@@ -10,7 +10,7 @@ import sentry_sdk
 from vaccine import ask_a_question_config as config
 from vaccine.base_application import BaseApplication
 from vaccine.models import Message
-from vaccine.states import Choice, ChoiceState, EndState, FreeText, KeywordState
+from vaccine.states import Choice, ChoiceState, EndState, FreeText
 from vaccine.utils import HTTP_EXCEPTIONS
 from vaccine.validators import nonempty_validator
 
@@ -217,24 +217,15 @@ class Application(BaseApplication):
         return await self.go_to_state("state_end")
 
     async def state_end(self):
-        question = self._(
+        text = self._(
             "Thank you for confirming.\n"
             "\n"
             "-----\n"
             "Reply:\n"
-            "⤴️ *BACK* to return to search results\n"
+            "❓ *ASK* to ask more vaccine questions\n"
             "📌 *0* for the main *MENU*"
         )
-        return KeywordState(
-            self,
-            question=question,
-            keywords={
-                "⤴️": "state_display_selected_choice",
-                "back": "state_display_selected_choice",
-                "*back": "state_display_selected_choice",
-            },
-            default="state_exit",
-        )
+        return EndState(self, text=text)
 
     async def state_error(self):
         return EndState(

--- a/vaccine/states.py
+++ b/vaccine/states.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from inspect import iscoroutinefunction
-from typing import TYPE_CHECKING, Awaitable, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Awaitable, Callable, List, Optional, Union
 
 from vaccine.models import Message
 from vaccine.utils import get_display_choices
@@ -102,32 +102,6 @@ class ChoiceState:
         if self.footer is not None:
             text = f"{text}\n{self.footer}"
         return self.app.send_message(text)
-
-
-class KeywordState:
-    def __init__(
-        self,
-        app: "BaseApplication",
-        question: str,
-        keywords: Dict[str, str],
-        default: str,
-    ):
-        self.app = app
-        self.question = question
-        self.keywords = keywords
-        self.default = default
-
-    async def process_message(self, message: Message):
-        content = (message.content or "").strip().lower()
-        state_name = self.keywords.get(content)
-        if state_name:
-            self.app.save_answer(self.app.state_name, content)
-        self.app.state_name = state_name or self.default
-        state = await self.app.get_current_state()
-        return await state.display(message)
-
-    async def display(self, message: Message):
-        return self.app.send_message(self.question)
 
 
 class MenuState(ChoiceState):

--- a/vaccine/tests/test_ask_a_question.py
+++ b/vaccine/tests/test_ask_a_question.py
@@ -89,10 +89,10 @@ async def test_question(tester: AppTester, model_mock):
     tester.assert_message(
         "\n".join(
             [
-                "❓ *YOUR VACCINE QUESTIONS*",
+                "❓ *ASK*  your questions about vaccines",
                 "",
-                "Search our knowledge hub by *typing your own question* or sharing a "
-                "'*rumour*' that's going around to get the facts!",
+                "Try *typing your own question* or sharing/forwarding a '*rumour*' "
+                "that's going around to get the facts!",
                 "",
                 '[💡Tip: Reply with a question like: "_Are vaccines safe?"_]',
             ]

--- a/vaccine/tests/test_ask_a_question.py
+++ b/vaccine/tests/test_ask_a_question.py
@@ -226,7 +226,6 @@ async def test_display_selected_choice(tester: AppTester, model_mock):
     )
 
     await tester.user_input("1")
-    tester.assert_state("state_end")
     [request] = model_mock.app.requests
     assert request.json == {
         "feedback": {"choice": "Are COVID-19 vaccines safe?", "feedback": "yes"},
@@ -244,7 +243,6 @@ async def test_display_selected_choice_temporary_error(tester: AppTester, model_
     model_mock.app.errormax = 1
     tester.setup_state("state_display_selected_choice")
     await tester.user_input("1")
-    tester.assert_state("state_end")
     assert len(model_mock.app.requests) == 2
 
 
@@ -280,20 +278,9 @@ async def test_state_end(tester: AppTester, model_mock):
                 "",
                 "-----",
                 "Reply:",
-                "⤴️ *BACK* to return to search results",
+                "❓ *ASK* to ask more vaccine questions",
                 "📌 *0* for the main *MENU*",
             ]
-        )
+        ),
+        session=Message.SESSION_EVENT.CLOSE,
     )
-    tester.assert_state("state_end")
-
-    await tester.user_input("⤴️")
-    tester.assert_state("state_display_selected_choice")
-
-
-@pytest.mark.asyncio
-async def test_state_end_invalid(tester: AppTester, model_mock):
-    tester.setup_state("state_end")
-    await tester.user_input("invalid")
-    tester.assert_message("", session=Message.SESSION_EVENT.CLOSE)
-    assert tester.application.messages[0].helper_metadata["automation_handle"] is True


### PR DESCRIPTION
- Copy change for question
The copy for the question state was changed to better reference the ASK keyword

- end state UX improvement
The previous UX was confusing, so instead it's been replaced with just a normal EndState, with references to the ASK keyword to start the flow again
