### PR TITLE
AAQ UX improvements

### DIFF
--- a/vaccine/ask_a_question.py
+++ b/vaccine/ask_a_question.py
@@ -179,7 +179,10 @@ class Application(BaseApplication):
         return ChoiceState(
             self,
             question=question,
-            choices=[Choice("yes", self._("*YES*")), Choice("no", self._("*NO*"))],
+            choices=[
+                Choice("yes", self._("*YES*"), ["yes"]),
+                Choice("no", self._("*NO*"), ["no"]),
+            ],
             error=question,
             next="state_submit_user_feedback",
         )

--- a/vaccine/tests/test_ask_a_question.py
+++ b/vaccine/tests/test_ask_a_question.py
@@ -235,6 +235,46 @@ async def test_display_selected_choice(tester: AppTester, model_mock):
 
 
 @pytest.mark.asyncio
+async def test_display_selected_choice_no_feedback(tester: AppTester, model_mock):
+    with open("vaccine/tests/aaq_model_response.json") as f:
+        tester.setup_answer("model_response", f.read())
+
+    tester.setup_state("state_display_response_choices")
+    await tester.user_input("1")
+    tester.assert_state("state_display_selected_choice")
+    await tester.user_input("no")
+    [request] = model_mock.app.requests
+    assert request.json == {
+        "feedback": {"choice": "Are COVID-19 vaccines safe?", "feedback": "no"},
+        "feedback_secret_key": "testsecretkey",
+        "inbound_id": 66,
+    }
+    tester.assert_state("state_another_result")
+    tester.assert_message(
+        "\n".join(
+            [
+                "Thank you for confirming.",
+                "",
+                "Try a different result?",
+                "1. Are COVID-19 vaccines safe?",
+                "2. Do vaccines work against COVID-19 variants?",
+                "3. Do we know what's in the vaccines?",
+                "",
+                "-----",
+                "Reply:",
+                "❓ *ASK* to ask more vaccine questions",
+                "📌 *0* for the main *MENU*",
+            ]
+        )
+    )
+    await tester.user_input("2")
+    tester.assert_state("state_display_selected_choice")
+    tester.assert_answer(
+        "state_display_response_choices", "Do vaccines work against COVID-19 variants?"
+    )
+
+
+@pytest.mark.asyncio
 async def test_display_selected_choice_temporary_error(tester: AppTester, model_mock):
     with open("vaccine/tests/aaq_model_response.json") as f:
         tester.setup_answer("model_response", f.read())

--- a/vaccine/tests/test_ask_a_question.py
+++ b/vaccine/tests/test_ask_a_question.py
@@ -225,7 +225,7 @@ async def test_display_selected_choice(tester: AppTester, model_mock):
         )
     )
 
-    await tester.user_input("1")
+    await tester.user_input("yes")
     [request] = model_mock.app.requests
     assert request.json == {
         "feedback": {"choice": "Are COVID-19 vaccines safe?", "feedback": "yes"},


### PR DESCRIPTION
- Allow additional keywords for answer confirmation
Currently, because the options are bolded, it will only accept `*yes*`, not `yes`. To solve this, I've added an `additional_keywords` argument, that allows you to specify additional keywords that should also match
- Cycle back to question list if answer doesn't answer question
If the user selects "No" to if the answer answered their question, we should give them the opportunity to choose a different FAQ from this list
