### PR TITLE
Fix exit keywords

### DIFF
--- a/vaccine/ask_a_question.py
+++ b/vaccine/ask_a_question.py
@@ -40,7 +40,10 @@ class Application(BaseApplication):
     async def process_message(self, message: Message) -> List[Message]:
         if message.session_event == Message.SESSION_EVENT.CLOSE:
             self.state_name = "state_timeout"
-        if re.sub(r"\W+", " ", message.content or "").strip().lower() in (
+        keyword = re.sub(r"\W+", " ", message.content or "").strip().lower()
+        if keyword in ("ask",) and self.state_name not in (None, self.START_STATE):
+            self.state_name = "state_exit"
+        if keyword in (
             "menu",
             "0",
             "faq",
@@ -49,7 +52,6 @@ class Application(BaseApplication):
             "vaccine",
             "check",
             "register",
-            "ask",
         ):
             self.state_name = "state_exit"
 

--- a/vaccine/tests/test_ask_a_question.py
+++ b/vaccine/tests/test_ask_a_question.py
@@ -85,7 +85,7 @@ async def test_timeout(tester: AppTester):
 
 @pytest.mark.asyncio
 async def test_question(tester: AppTester, model_mock):
-    await tester.user_input(session=Message.SESSION_EVENT.NEW)
+    await tester.user_input("ask", session=Message.SESSION_EVENT.NEW)
     tester.assert_message(
         "\n".join(
             [


### PR DESCRIPTION
We added the `ask` keyword as an exit keyword, so that at any point the user could restart the flow to ask another question, eg. after they receive an answer that doesn't answer their question. But if we don't check if we're in the beginning of the flow, then when they send the initial `ask` keyword, they're immediately kicked out of the flow.

This fixes that issue﻿
