### PR TITLE
Only resume USSD if in sub-application

### DIFF
--- a/vaccine/healthcheck_vacreg_ussd.py
+++ b/vaccine/healthcheck_vacreg_ussd.py
@@ -74,7 +74,10 @@ class Application(VacRegApp, HealthCheckApp):
         if (
             message.session_event == Message.SESSION_EVENT.NEW
             and self.state_name is not None
-            and self.state_name != self.START_STATE
+            and (
+                hasattr(VacRegApp, self.state_name)
+                or hasattr(HealthCheckApp, self.state_name)
+            )
         ):
             self.save_answer("resume_state", self.state_name)
             if hasattr(VacRegApp, self.state_name):

--- a/vaccine/tests/test_healthcheck_vacreg_ussd.py
+++ b/vaccine/tests/test_healthcheck_vacreg_ussd.py
@@ -413,6 +413,15 @@ async def test_state_timed_out_vaccinereg():
     assert u.session_id != 1
 
 
+async def test_state_timed_out_timed_out():
+    tester = AppTester(Application)
+    tester.setup_state("state_timed_out_vacreg")
+    tester.setup_answer("resume_state", "state_vaccination_time")
+    await tester.user_input(session=Message.SESSION_EVENT.NEW)
+    tester.assert_state("state_timed_out_vacreg")
+    tester.assert_answer("resume_state", "state_vaccination_time")
+
+
 async def test_state_language():
     tester = AppTester(Application)
     tester.setup_state("state_menu")


### PR DESCRIPTION
Previously, if you timed out in the timeout state, it would overwrite the resume state, and put the in the healthcheck, even if you were in the vaccine registration.

If you are in the top level app, and not in one of the sub apps, then we shouldn't worry about showing the timeout message.﻿
