### PR TITLE
Don't allow SA ID numbers for other identification types

### DIFF
--- a/vaccine/tests/test_vaccine_reg_whatsapp.py
+++ b/vaccine/tests/test_vaccine_reg_whatsapp.py
@@ -209,6 +209,39 @@ async def test_identification_number_invalid(tester: AppTester):
 
 
 @pytest.mark.asyncio
+async def test_identification_number_said_on_passport(tester: AppTester):
+    tester.setup_state("state_identification_number")
+    tester.setup_answer("state_identification_type", "passport")
+    await tester.user_input("9001010001088")
+    tester.assert_state("state_check_id_number")
+    tester.assert_num_messages(1)
+
+
+@pytest.mark.asyncio
+async def test_check_id_number(tester: AppTester):
+    tester.setup_state("state_identification_number")
+    tester.setup_answer("state_identification_type", "passport")
+    await tester.user_input("9001010001088")
+    tester.assert_state("state_check_id_number")
+    tester.assert_num_messages(1)
+    await tester.user_input("yes")
+    tester.assert_answer("state_identification_type", "rsa_id")
+    tester.assert_state("state_first_name")
+
+
+@pytest.mark.asyncio
+async def test_check_id_number_restart(tester: AppTester):
+    tester.setup_state("state_identification_number")
+    tester.setup_answer("state_identification_type", "passport")
+    await tester.user_input("9001010001088")
+    tester.assert_num_messages(1)
+    tester.assert_state("state_check_id_number")
+    await tester.user_input("no")
+    tester.assert_num_messages(1)
+    tester.assert_state("state_identification_type")
+
+
+@pytest.mark.asyncio
 async def test_passport_country(tester: AppTester):
     tester.setup_state("state_identification_number")
     tester.setup_answer("state_identification_type", "passport")

--- a/vaccine/vaccine_reg_ussd.py
+++ b/vaccine/vaccine_reg_ussd.py
@@ -75,7 +75,7 @@ class Application(BaseApplication):
 
         class ID_TYPES(Enum):
             rsa_id = self._("RSA ID Number")
-            passport = self._("Passport Number")
+            passport = self._("NON-RSA Passport Number")
             asylum_seeker = self._("Asylum Seeker Permit number")
             refugee = self._("Refugee Permit number")
 

--- a/vaccine/vaccine_reg_ussd.py
+++ b/vaccine/vaccine_reg_ussd.py
@@ -185,13 +185,8 @@ class Application(BaseApplication):
         idtype = self.ID_TYPES[self.user.answers["state_identification_type"]]
         idtype_label = idtype.value
 
-        if idtype == self.ID_TYPES.passport:
-            next_state = "state_passport_country"
-        else:
-            next_state = "state_gender"
-
         if self.user.answers.get("state_identification_number"):
-            return await self.go_to_state(next_state)
+            return await self.go_to_state("state_check_id_number")
 
         async def validate_identification_number(value):
             error_msg = self._("Invalid {id_type}. Please try again").format(
@@ -214,9 +209,49 @@ class Application(BaseApplication):
         return FreeText(
             self,
             question=self._("Please enter your {id_type}").format(id_type=idtype_label),
-            next=next_state,
+            next="state_check_id_number",
             check=validate_identification_number,
         )
+
+    async def state_check_id_number(self):
+        """
+        Checks to see if there's an SA ID number for a non-SA ID ID type
+        """
+        idtype = self.ID_TYPES[self.user.answers["state_identification_type"]]
+        idnumber = self.user.answers["state_identification_number"]
+
+        try:
+            SAIDNumber(idnumber)
+            if idtype != self.ID_TYPES.rsa_id:
+                return MenuState(
+                    self,
+                    question=self._(
+                        "The number you have entered appears to be a RSA ID Number. Is "
+                        "this correct?\n"
+                    ),
+                    choices=[
+                        Choice("state_change_to_rsa_id", self._("Yes")),
+                        Choice("state_reset_identification", self._("No")),
+                    ],
+                    error=self._("This looks like an SA ID number"),
+                )
+        except ValueError:
+            pass
+
+        if idtype == self.ID_TYPES.passport:
+            next_state = "state_passport_country"
+        else:
+            next_state = "state_gender"
+        return await self.go_to_state(next_state)
+
+    async def state_change_to_rsa_id(self):
+        self.save_answer("state_identification_type", self.ID_TYPES.rsa_id.name)
+        return await self.go_to_state("state_gender")
+
+    async def state_reset_identification(self):
+        del self.user.answers["state_identification_type"]
+        del self.user.answers["state_identification_number"]
+        return await self.go_to_state("state_identification_type")
 
     async def state_passport_country(self):
         async def next_state(choice: Choice):

--- a/vaccine/vaccine_reg_whatsapp.py
+++ b/vaccine/vaccine_reg_whatsapp.py
@@ -80,7 +80,7 @@ class Application(BaseApplication):
 
         class ID_TYPES(Enum):
             rsa_id = self._("RSA ID Number")
-            passport = self._("Passport Number")
+            passport = self._("NON-RSA Passport Number")
             asylum_seeker = self._("Asylum Seeker Permit number")
             refugee = self._("Refugee Permit number")
 


### PR DESCRIPTION
- Change copy for passport number ID type
- Don't allow SA ID numbers for other identification types
