### PR TITLE
Move SAID autofill to individual states

### DIFF
--- a/vaccine/vaccine_reg_ussd.py
+++ b/vaccine/vaccine_reg_ussd.py
@@ -194,13 +194,7 @@ class Application(BaseApplication):
             )
             if idtype == self.ID_TYPES.rsa_id:
                 try:
-                    id_number = SAIDNumber(value)
-                    dob = id_number.date_of_birth
-                    if id_number.age > config.AMBIGUOUS_MAX_AGE - 100:
-                        self.save_answer("state_dob_year", str(dob.year))
-                    self.save_answer("state_dob_month", str(dob.month))
-                    self.save_answer("state_dob_day", str(dob.day))
-                    self.save_answer("state_gender", id_number.sex.value)
+                    SAIDNumber(value)
                 except ValueError:
                     raise ErrorMessage(error_msg)
             else:
@@ -303,6 +297,11 @@ class Application(BaseApplication):
         )
 
     async def state_gender(self):
+        idtype = self.ID_TYPES[self.user.answers["state_identification_type"]]
+        if idtype == self.ID_TYPES.rsa_id:
+            id_number = SAIDNumber(self.user.answers["state_identification_number"])
+            self.save_answer("state_gender", id_number.sex.value)
+
         if self.user.answers.get("state_gender"):
             return await self.go_to_state("state_dob_year")
 
@@ -319,6 +318,12 @@ class Application(BaseApplication):
         )
 
     async def state_dob_year(self):
+        idtype = self.ID_TYPES[self.user.answers["state_identification_type"]]
+        if idtype == self.ID_TYPES.rsa_id:
+            id_number = SAIDNumber(self.user.answers["state_identification_number"])
+            if id_number.age > config.AMBIGUOUS_MAX_AGE - 100:
+                self.save_answer("state_dob_year", str(id_number.date_of_birth.year))
+
         if self.user.answers.get("state_dob_year"):
             return await self.go_to_state("state_dob_month")
 
@@ -358,6 +363,11 @@ class Application(BaseApplication):
         )
 
     async def state_dob_month(self):
+        idtype = self.ID_TYPES[self.user.answers["state_identification_type"]]
+        if idtype == self.ID_TYPES.rsa_id:
+            id_number = SAIDNumber(self.user.answers["state_identification_number"])
+            self.save_answer("state_dob_month", str(id_number.date_of_birth.month))
+
         if self.user.answers.get("state_dob_month"):
             return await self.go_to_state("state_dob_day")
 
@@ -385,6 +395,11 @@ class Application(BaseApplication):
         )
 
     async def state_dob_day(self):
+        idtype = self.ID_TYPES[self.user.answers["state_identification_type"]]
+        if idtype == self.ID_TYPES.rsa_id:
+            id_number = SAIDNumber(self.user.answers["state_identification_number"])
+            self.save_answer("state_dob_day", str(id_number.date_of_birth.day))
+
         if self.user.answers.get("state_dob_day"):
             return await self.go_to_state("state_first_name")
 

--- a/vaccine/vaccine_reg_whatsapp.py
+++ b/vaccine/vaccine_reg_whatsapp.py
@@ -485,13 +485,7 @@ class Application(BaseApplication):
             ).format(id_type=idtype_label)
             if idtype == self.ID_TYPES.rsa_id:
                 try:
-                    id_number = SAIDNumber(value)
-                    dob = id_number.date_of_birth
-                    if id_number.age > config.AMBIGUOUS_MAX_AGE - 100:
-                        self.save_answer("state_dob_year", str(dob.year))
-                    self.save_answer("state_dob_month", str(dob.month))
-                    self.save_answer("state_dob_day", str(dob.day))
-                    self.save_answer("state_gender", id_number.sex.value)
+                    SAIDNumber(value)
                 except ValueError:
                     raise ErrorMessage(error_msg)
             else:
@@ -649,6 +643,12 @@ class Application(BaseApplication):
         )
 
     async def state_dob_year(self):
+        idtype = self.ID_TYPES[self.user.answers["state_identification_type"]]
+        if idtype == self.ID_TYPES.rsa_id:
+            id_number = SAIDNumber(self.user.answers["state_identification_number"])
+            if id_number.age > config.AMBIGUOUS_MAX_AGE - 100:
+                self.save_answer("state_dob_year", str(id_number.date_of_birth.year))
+
         if self.user.answers.get("state_dob_year"):
             return await self.go_to_state("state_dob_month")
 
@@ -689,6 +689,11 @@ class Application(BaseApplication):
         )
 
     async def state_dob_month(self):
+        idtype = self.ID_TYPES[self.user.answers["state_identification_type"]]
+        if idtype == self.ID_TYPES.rsa_id:
+            id_number = SAIDNumber(self.user.answers["state_identification_number"])
+            self.save_answer("state_dob_month", str(id_number.date_of_birth.month))
+
         if self.user.answers.get("state_dob_month"):
             return await self.go_to_state("state_dob_day")
 
@@ -724,6 +729,11 @@ class Application(BaseApplication):
         )
 
     async def state_dob_day(self):
+        idtype = self.ID_TYPES[self.user.answers["state_identification_type"]]
+        if idtype == self.ID_TYPES.rsa_id:
+            id_number = SAIDNumber(self.user.answers["state_identification_number"])
+            self.save_answer("state_dob_day", str(id_number.date_of_birth.day))
+
         if self.user.answers.get("state_dob_day"):
             return await self.go_to_state("state_gender")
 
@@ -758,6 +768,11 @@ class Application(BaseApplication):
         )
 
     async def state_gender(self):
+        idtype = self.ID_TYPES[self.user.answers["state_identification_type"]]
+        if idtype == self.ID_TYPES.rsa_id:
+            id_number = SAIDNumber(self.user.answers["state_identification_number"])
+            self.save_answer("state_gender", id_number.sex.value)
+
         year = int(self.user.answers["state_dob_year"])
         month = int(self.user.answers["state_dob_month"])
         day = int(self.user.answers["state_dob_day"])


### PR DESCRIPTION
With allowing the user to switch to SA ID type midway in the flow if they typed an SA ID number, the date of birth and gender fields were not getting auto filled for that branch.

In order to fix that, I've moved the autofill to each of the individual states, so that each state is responsible for its own autofilling and skipping if required.﻿
