### PR TITLE
Fix real411 file upload

### DIFF
--- a/vaccine/real411.py
+++ b/vaccine/real411.py
@@ -407,11 +407,7 @@ class Application(BaseApplication):
                     file_data = BLANK_PNG
                 else:
                     file_data = await get_whatsapp_media(file["name"])
-                data = aiohttp.FormData()
-                data.add_field(
-                    "file", file_data, filename=file["name"], content_type=file["type"]
-                )
-                result = await session.post(file_url, data=data)
+                result = await session.put(file_url, data=file_data)
                 result.raise_for_status()
 
         await finalise_real411_form(form_reference)

--- a/vaccine/tests/test_real411.py
+++ b/vaccine/tests/test_real411.py
@@ -25,7 +25,7 @@ async def real411_mock(sanic_client):
             "vaccine/tests/real411.json", mime_type="application/json"
         )
 
-    @app.route("/file_upload", methods=["POST"])
+    @app.route("/file_upload", methods=["PUT"])
     def file_upload(request):
         app.requests.append(request)
         return response.text("")
@@ -455,12 +455,8 @@ async def test_success(tester: AppTester, real411_mock, whatsapp_mock):
             {"name": "img1", "type": "image/jpeg"},
         ],
     }
-    assert uploadvid.files["file"][0].body == b"testfile"
-    assert uploadvid.files["file"][0].name == "vid1"
-    assert uploadvid.files["file"][0].type == "video/mp4"
-    assert uploadimg.files["file"][0].body == b"testfile"
-    assert uploadimg.files["file"][0].name == "img1"
-    assert uploadimg.files["file"][0].type == "image/jpeg"
+    assert uploadvid.body == b"testfile"
+    assert uploadimg.body == b"testfile"
     assert finalise.json == {"ref": 1}
 
 
@@ -489,9 +485,7 @@ async def test_success_no_media(tester: AppTester, real411_mock, whatsapp_mock):
         "source": 1,
         "file_names": [{"name": "placeholder", "type": "image/png"}],
     }
-    assert upload.files["file"][0].body == BLANK_PNG
-    assert upload.files["file"][0].name == "placeholder"
-    assert upload.files["file"][0].type == "image/png"
+    assert upload.body == BLANK_PNG
     assert finalise.json == {"ref": 1}
 
 


### PR DESCRIPTION
File upload should mimic curl's --file-upload, which is a PUT request with the file data in the request body
