### PR TITLE
Real411 handle unsupported MIME types

### DIFF
--- a/vaccine/tests/test_real411.py
+++ b/vaccine/tests/test_real411.py
@@ -445,6 +445,39 @@ async def test_media(tester: AppTester):
 
 
 @pytest.mark.asyncio
+async def test_media_invalid_mimetype(tester: AppTester):
+    tester.setup_state("state_description")
+    await tester.user_input(
+        "test description",
+        transport_metadata={
+            "message": {"type": "document", "mime_type": "application/msword"}
+        },
+    )
+    tester.assert_state("state_description")
+    tester.assert_message(
+        "\n".join(
+            [
+                "I'm afraid we cannot read the file that you sent through.",
+                "",
+                "We can only read video, image, document or audio files that have "
+                "these letters at the end of the file name:",
+                ".mp4",
+                ".jpeg",
+                ".png",
+                ".pdf",
+                ".ogg",
+                ".wave",
+                ".x-wav",
+                "",
+                "If you cannot send one of these files, don't worry. We will "
+                "investigate based on the description of the problem that you already "
+                "typed in.",
+            ]
+        )
+    )
+
+
+@pytest.mark.asyncio
 async def test_opt_in(tester: AppTester):
     tester.setup_state("state_media")
     await tester.user_input("SKIP")

--- a/vaccine/validators.py
+++ b/vaccine/validators.py
@@ -57,3 +57,18 @@ def email_validator(error_text: str, skip_keywords: Iterable[str] = []):
             raise ErrorMessage(error_text.format(email_error=e))
 
     return validator
+
+
+def enforce_mime_types(app, error, mime_types):
+    """
+    Ensure that if media is sent, it is one of a set of mime types
+    """
+
+    async def validator(content: Optional[str]):
+        msg_type = app.inbound.transport_metadata.get("message", {}).get("type")
+        if msg_type in ["audio", "document", "image", "video", "voice", "sticker"]:
+            media = app.inbound.transport_metadata.get("message", {}).get(msg_type, {})
+            if media.get("mime_type") not in mime_types:
+                raise ErrorMessage(error)
+
+    return validator


### PR DESCRIPTION
- Allow check to be list of validators
- Add validator for media mime types
- Show error message if media with invalid mime type is sent
