### PR TITLE
Add additional mime types that will allow voicenotes to be submitted

### DIFF
--- a/vaccine/real411.py
+++ b/vaccine/real411.py
@@ -28,9 +28,14 @@ ACCEPTED_MIME_TYPES = [
     "image/png",
     "application/pdf",
     "audio/ogg",
+    "audio/ogg; codecs=opus",
     "video/ogg",
     "audio/wav",
     "audio/x-wav",
+    "audio/aac",
+    "audio/mp4",
+    "audio/amr",
+    "audio/mpeg",
 ]
 
 
@@ -392,6 +397,10 @@ class Application(BaseApplication):
             "\n"
             "We can only read video, image, document or audio files that have these "
             "letters at the end of the file name:\n"
+            ".amr\n"
+            ".aac\n"
+            ".m4a\n"
+            ".mp3\n"
             ".mp4\n"
             ".jpeg\n"
             ".png\n"
@@ -418,13 +427,17 @@ class Application(BaseApplication):
             "*REPORT* 📵 powered by ```Real411.org```\n"
             "\n"
             "Please share any extra information, such as screenshots, photos, "
-            "or links (or type SKIP)"
+            "voicenotes or links (or type SKIP)"
         )
         error = self._(
             "I'm afraid we cannot read the file that you sent through.\n"
             "\n"
             "We can only read video, image, document or audio files that have these "
             "letters at the end of the file name:\n"
+            ".amr\n"
+            ".aac\n"
+            ".m4a\n"
+            ".mp3\n"
             ".mp4\n"
             ".jpeg\n"
             ".png\n"

--- a/vaccine/tests/test_real411.py
+++ b/vaccine/tests/test_real411.py
@@ -436,7 +436,7 @@ async def test_media(tester: AppTester):
                 "*REPORT* 📵 powered by ```Real411.org```",
                 "",
                 "Please share any extra information, such as screenshots, photos, "
-                "or links (or type SKIP)",
+                "voicenotes or links (or type SKIP)",
             ]
         )
     )
@@ -462,6 +462,10 @@ async def test_media_invalid_mimetype(tester: AppTester):
                 "",
                 "We can only read video, image, document or audio files that have "
                 "these letters at the end of the file name:",
+                ".amr",
+                ".aac",
+                ".m4a",
+                ".mp3",
                 ".mp4",
                 ".jpeg",
                 ".png",


### PR DESCRIPTION
Real411 will be adding the additional mime types to their API, in order to support voice notes. This PR makes the changes to allow those mime types through to the API, so that we can support users sending in voicenotes﻿
