### PR TITLE
YAL: ask a question timeouts

### DIFF
--- a/yal/askaquestion.py
+++ b/yal/askaquestion.py
@@ -1,0 +1,228 @@
+import asyncio
+import logging
+from datetime import timedelta
+
+from vaccine.base_application import BaseApplication
+from vaccine.states import (
+    Choice,
+    EndState,
+    FreeText,
+    WhatsAppButtonState,
+    WhatsAppListState,
+)
+from yal import rapidpro
+from yal.utils import (
+    GENERIC_ERROR,
+    clean_inbound,
+    get_current_datetime,
+    normalise_phonenumber,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class Application(BaseApplication):
+    START_STATE = "state_aaq_start"
+    TIMEOUT_RESPONSE_STATE = "state_handle_timeout_response"
+
+    async def state_aaq_start(self):
+        question = self._(
+            "\n".join(
+                [
+                    "🙋🏿‍♂️ *QUESTIONS?*",
+                    "Ask A Question",
+                    "-----",
+                    "",
+                    "🙍🏾‍♀️*That's what I'm here for!*",
+                    "*Just type your Q and hit send* .🙂.",
+                    "",
+                    "e.g. _How do I know if I have an STI?_",
+                    "",
+                    "-----",
+                    "*Or reply:*",
+                    "*0* - 🏠 Back to Main *MENU*",
+                ]
+            )
+        )
+        return FreeText(
+            self,
+            question=question,
+            next="state_set_aaq_timeout_1",  # TODO send question to api
+            # TODO add validator
+        )
+
+    async def state_set_aaq_timeout_1(self):
+        msisdn = normalise_phonenumber(self.inbound.from_addr)
+        whatsapp_id = msisdn.lstrip(" + ")
+
+        timeout_time = get_current_datetime() + timedelta(minutes=5)
+        data = {
+            "next_aaq_timeout_time": timeout_time.isoformat(),
+            "aaq_timeout_type": "1",
+        }
+
+        error = await rapidpro.update_profile(whatsapp_id, data)
+        if error:
+            return await self.go_to_state("state_error")
+
+        return await self.go_to_state("state_display_results")
+
+    async def state_display_results(self):
+        question = self._(
+            "\n".join(
+                [
+                    "🙋🏿‍♂️ QUESTIONS?",
+                    "*Ask A Question*",
+                    "-----",
+                    "",
+                    "🙍🏾‍♀️Here are some FAQs that might answer your question." "",
+                    "*To see the answer, reply with the number of the FAQ "
+                    "you're interested in:*",
+                    "",
+                    "*1* - {{AAQ Title #1}}",
+                    "*2* - {{AAQ Title #2}}",
+                    "*3* - {{AAQ Title #3}}",
+                    "*4* - None of these answer my question",
+                    "",
+                    "-----",
+                    "*Or reply:*",
+                    "*0* - 🏠 Back to Main *MENU*",
+                    "# - 🆘 Get HELP",
+                ]
+            )
+        )
+        return WhatsAppListState(
+            self,
+            question=question,
+            button="Choose an option",
+            choices=[
+                Choice("title_1", self._("AAQ Title #1")),
+                Choice("title_2", self._("AAQ Title #2")),
+                Choice("title_3", self._("AAQ Title #3")),
+                Choice("no match", self._("None of these help")),
+            ],
+            next="state_set_aaq_timeout_2",
+            error=self._(GENERIC_ERROR),
+        )
+
+    async def state_set_aaq_timeout_2(self):
+        chosen_answer = self.user.answers.get("state_display_results")
+
+        if chosen_answer == "no match":
+            return await self.go_to_state("state_is_question_answered")
+
+        msisdn = normalise_phonenumber(self.inbound.from_addr)
+        whatsapp_id = msisdn.lstrip(" + ")
+
+        timeout_time = get_current_datetime() + timedelta(minutes=5)
+        data = {
+            "next_aaq_timeout_time": timeout_time.isoformat(),
+            "aaq_timeout_type": "2",
+        }
+
+        error = await rapidpro.update_profile(whatsapp_id, data)
+        if error:
+            return await self.go_to_state("state_error")
+
+        return await self.go_to_state("state_display_content")
+
+    async def state_display_content(self):
+        msg = self._(
+            "\n".join(
+                [
+                    "TODO: display chosen answer",
+                ]
+            )
+        )
+        await self.worker.publish_message(
+            self.inbound.reply(
+                msg,
+            )
+        )
+        await asyncio.sleep(1.5)
+        question = self._(
+            "\n".join(
+                [
+                    "*Did we answer your question?*",
+                    "",
+                    "*Reply:*",
+                    "*1* - Yes 👍",
+                    "*2* - No 👎",
+                ]
+            )
+        )
+        return WhatsAppButtonState(
+            self,
+            question=question,
+            choices=[
+                Choice("yes", "Yes"),
+                Choice("no", "No"),
+            ],
+            error=self._(GENERIC_ERROR),
+            next="state_is_question_answered",
+        )
+
+    async def state_is_question_answered(self):
+        msisdn = normalise_phonenumber(self.inbound.from_addr)
+        whatsapp_id = msisdn.lstrip(" + ")
+
+        data = {
+            "aaq_timeout_type": "",
+        }
+
+        error = await rapidpro.update_profile(whatsapp_id, data)
+        if error:
+            return await self.go_to_state("state_error")
+
+        if self.user.answers.get("state_display_content", None) == "yes":
+            return await self.go_to_state("state_yes_question_answered")
+        return await self.go_to_state("state_no_question_not_answered")
+
+    async def state_yes_question_answered(self):
+        return EndState(
+            self,
+            self._(
+                "🙍🏾‍♀️*So glad I could help! If you have another question, "
+                "you know what to do!* 😉"
+            ),
+            next=self.START_STATE,
+        )
+
+    async def state_no_question_not_answered(self):
+        return EndState(
+            self,
+            self._("TODO: Handle question not answered"),
+            next=self.START_STATE,
+        )
+
+    async def state_handle_timeout_response(self):
+        msisdn = normalise_phonenumber(self.inbound.from_addr)
+        whatsapp_id = msisdn.lstrip(" + ")
+
+        error, fields = await rapidpro.get_profile(whatsapp_id)
+        if error:
+            return await self.go_to_state("state_error")
+
+        data = {
+            "aaq_timeout_sent": "",
+            "aaq_timeout_type": "",
+        }
+        error = await rapidpro.update_profile(whatsapp_id, data)
+        if error:
+            return await self.go_to_state("state_error")
+
+        timeout_type_sent = fields.get("aaq_timeout_type")
+        inbound = clean_inbound(self.inbound.content)
+
+        if timeout_type_sent == "1":
+            if inbound == "yes ask again":
+                return await self.go_to_state("state_aaq_start")
+            return EndState(
+                self,
+                self._("Ok"),
+                next=self.START_STATE,
+            )
+        if timeout_type_sent == "2":
+            if inbound == "yes":
+                return await self.go_to_state("state_yes_question_answered")
+            return await self.go_to_state("state_no_question_not_answered")

--- a/yal/tests/test_askaquestion.py
+++ b/yal/tests/test_askaquestion.py
@@ -1,0 +1,262 @@
+import json
+from datetime import datetime
+from unittest import mock
+
+import pytest
+from sanic import Sanic, response
+
+from vaccine.models import Message
+from vaccine.testing import AppTester
+from yal import config
+from yal.main import Application
+
+
+@pytest.fixture
+def tester():
+    return AppTester(Application)
+
+
+def get_rapidpro_contact(urn):
+    return {
+        "fields": {
+            "aaq_timeout_type": "1" if ("27820001001" in urn) else "2",
+        },
+    }
+
+
+@pytest.fixture
+async def rapidpro_mock(sanic_client):
+    Sanic.test_mode = True
+    app = Sanic("mock_rapidpro")
+    app.requests = []
+
+    @app.route("/api/v2/contacts.json", methods=["GET"])
+    def get_contact(request):
+        app.requests.append(request)
+
+        urn = request.args.get("urn")
+        contacts = [get_rapidpro_contact(urn)]
+
+        return response.json(
+            {
+                "results": contacts,
+                "next": None,
+            },
+            status=200,
+        )
+
+    @app.route("/api/v2/contacts.json", methods=["POST"])
+    def update_contact(request):
+        app.requests.append(request)
+        return response.json({}, status=200)
+
+    client = await sanic_client(app)
+    url = config.RAPIDPRO_URL
+    config.RAPIDPRO_URL = f"http://{client.host}:{client.port}"
+    config.RAPIDPRO_TOKEN = "testtoken"
+    yield client
+    config.RAPIDPRO_URL = url
+
+
+@pytest.mark.asyncio
+async def test_aaq_start(tester: AppTester, rapidpro_mock):
+    tester.setup_state("state_aaq_start")
+
+    await tester.user_input(session=Message.SESSION_EVENT.NEW)
+
+    tester.assert_state("state_aaq_start")
+    tester.assert_num_messages(1)
+    tester.assert_message(
+        "\n".join(
+            [
+                "🙋🏿‍♂️ *QUESTIONS?*",
+                "Ask A Question",
+                "-----",
+                "",
+                "🙍🏾‍♀️*That's what I'm here for!*",
+                "*Just type your Q and hit send* .🙂.",
+                "",
+                "e.g. _How do I know if I have an STI?_",
+                "",
+                "-----",
+                "*Or reply:*",
+                "*0* - 🏠 Back to Main *MENU*",
+            ]
+        )
+    )
+
+
+@pytest.mark.asyncio
+@mock.patch("yal.askaquestion.get_current_datetime")
+async def test_start_state_response_sets_timeout(
+    get_current_datetime, tester: AppTester, rapidpro_mock
+):
+    get_current_datetime.return_value = datetime(2022, 6, 19, 17, 30)
+    tester.setup_state("state_aaq_start")
+
+    await tester.user_input("How do you do?")
+
+    tester.assert_state("state_display_results")
+
+    assert len(rapidpro_mock.app.requests) == 1
+    request = rapidpro_mock.app.requests[0]
+    assert json.loads(request.body.decode("utf-8")) == {
+        "fields": {
+            "next_aaq_timeout_time": "2022-06-19T17:35:00",
+            "aaq_timeout_type": "1",
+        },
+    }
+
+
+@pytest.mark.asyncio
+@mock.patch("yal.askaquestion.get_current_datetime")
+async def test_state_display_results_choose_an_answer(
+    get_current_datetime, tester: AppTester, rapidpro_mock
+):
+    get_current_datetime.return_value = datetime(2022, 6, 19, 17, 30)
+    tester.setup_state("state_display_results")
+
+    await tester.user_input("AAQ Title #1")
+
+    tester.assert_state("state_display_content")
+
+    assert len(rapidpro_mock.app.requests) == 1
+    request = rapidpro_mock.app.requests[0]
+    assert json.loads(request.body.decode("utf-8")) == {
+        "fields": {
+            "next_aaq_timeout_time": "2022-06-19T17:35:00",
+            "aaq_timeout_type": "2",
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_state_display_results_no_match(tester: AppTester, rapidpro_mock):
+    tester.setup_state("state_display_results")
+
+    await tester.user_input("None of these help")
+
+    tester.assert_state("state_start")
+
+    assert len(rapidpro_mock.app.requests) == 1
+    request = rapidpro_mock.app.requests[0]
+    assert json.loads(request.body.decode("utf-8")) == {
+        "fields": {"aaq_timeout_type": ""},
+    }
+
+    tester.assert_num_messages(1)
+    tester.assert_message("TODO: Handle question not answered")
+
+
+@pytest.mark.asyncio
+async def test_state_display_content_question_answered(
+    tester: AppTester, rapidpro_mock
+):
+    tester.setup_state("state_display_content")
+
+    await tester.user_input("Yes")
+
+    tester.assert_state("state_start")
+
+    assert len(rapidpro_mock.app.requests) == 1
+    request = rapidpro_mock.app.requests[0]
+    assert json.loads(request.body.decode("utf-8")) == {
+        "fields": {"aaq_timeout_type": ""},
+    }
+
+    tester.assert_num_messages(1)
+    tester.assert_message(
+        "🙍🏾‍♀️*So glad I could help! If you have another question, "
+        "you know what to do!* 😉"
+    )
+
+
+@pytest.mark.asyncio
+async def test_state_display_content_question_not_answered(
+    tester: AppTester, rapidpro_mock
+):
+    tester.setup_state("state_display_content")
+
+    await tester.user_input("No")
+
+    tester.assert_state("state_start")
+
+    assert len(rapidpro_mock.app.requests) == 1
+    request = rapidpro_mock.app.requests[0]
+    assert json.loads(request.body.decode("utf-8")) == {
+        "fields": {"aaq_timeout_type": ""},
+    }
+
+    tester.assert_num_messages(1)
+    tester.assert_message("TODO: Handle question not answered")
+
+
+@pytest.mark.asyncio
+async def test_state_handle_timeout_handles_type_1_yes(
+    tester: AppTester, rapidpro_mock
+):
+    tester.setup_state("state_handle_timeout_response")
+    await tester.user_input(session=Message.SESSION_EVENT.NEW, content="yes ask again")
+
+    assert len(rapidpro_mock.app.requests) == 2
+    request = rapidpro_mock.app.requests[1]
+    assert json.loads(request.body.decode("utf-8")) == {
+        "fields": {"aaq_timeout_sent": "", "aaq_timeout_type": ""},
+    }
+
+    tester.assert_state("state_aaq_start")
+
+
+@pytest.mark.asyncio
+async def test_state_handle_timeout_handles_type_1_no(tester: AppTester, rapidpro_mock):
+    tester.setup_state("state_handle_timeout_response")
+    await tester.user_input(session=Message.SESSION_EVENT.NEW, content="no, I'm good")
+
+    assert len(rapidpro_mock.app.requests) == 2
+    request = rapidpro_mock.app.requests[1]
+    assert json.loads(request.body.decode("utf-8")) == {
+        "fields": {"aaq_timeout_sent": "", "aaq_timeout_type": ""},
+    }
+
+    tester.assert_state("state_start")
+
+
+@pytest.mark.asyncio
+async def test_state_handle_timeout_handles_type_2_yes(
+    tester: AppTester, rapidpro_mock
+):
+    tester.setup_user_address("27820001002")
+    tester.setup_state("state_handle_timeout_response")
+    await tester.user_input(session=Message.SESSION_EVENT.NEW, content="yes")
+
+    assert len(rapidpro_mock.app.requests) == 2
+    request = rapidpro_mock.app.requests[1]
+    assert json.loads(request.body.decode("utf-8")) == {
+        "fields": {"aaq_timeout_sent": "", "aaq_timeout_type": ""},
+    }
+
+    tester.assert_state("state_start")
+
+    tester.assert_num_messages(1)
+    tester.assert_message(
+        "🙍🏾‍♀️*So glad I could help! If you have another question, "
+        "you know what to do!* 😉"
+    )
+
+
+@pytest.mark.asyncio
+async def test_state_handle_timeout_handles_type_2_no(tester: AppTester, rapidpro_mock):
+    tester.setup_user_address("27820001002")
+    tester.setup_state("state_handle_timeout_response")
+    await tester.user_input(session=Message.SESSION_EVENT.NEW, content="no")
+
+    assert len(rapidpro_mock.app.requests) == 2
+    request = rapidpro_mock.app.requests[1]
+    assert json.loads(request.body.decode("utf-8")) == {
+        "fields": {"aaq_timeout_sent": "", "aaq_timeout_type": ""},
+    }
+
+    tester.assert_state("state_start")
+
+    tester.assert_num_messages(1)
+    tester.assert_message("TODO: Handle question not answered")

--- a/yal/tests/test_main.py
+++ b/yal/tests/test_main.py
@@ -7,6 +7,7 @@ from sanic import Sanic, response
 from vaccine.models import Message
 from vaccine.testing import AppTester
 from yal import config
+from yal.askaquestion import Application as AaqApplication
 from yal.change_preferences import Application as ChangePreferencesApplication
 from yal.main import Application
 from yal.mainmenu import Application as MainMenuApplication
@@ -27,8 +28,16 @@ def test_no_state_name_clashes():
     q_states = set(s for s in dir(QuizApplication) if s.startswith("state_"))
     pc_states = set(s for s in dir(PleaseCallMeApplication) if s.startswith("state_"))
     sf_states = set(s for s in dir(ServiceFinderApplication) if s.startswith("state_"))
+    aaq_states = set(s for s in dir(AaqApplication) if s.startswith("state_"))
     intersection = (
-        mm_states & on_states & te_states & cp_states & q_states & pc_states & sf_states
+        mm_states
+        & on_states
+        & te_states
+        & cp_states
+        & q_states
+        & pc_states
+        & sf_states
+        & aaq_states
     ) - {
         "state_name",
         "state_error",
@@ -52,6 +61,8 @@ def get_rapidpro_contact(urn):
             "onboarding_completed": "27820001001" in urn,
             "onboarding_reminder_sent": "27820001001" in urn,
             "callback_check_sent": "27820001001" in urn,
+            "aaq_timeout_sent": "27820001001" in urn,
+            "aaq_timeout_type": "2" if "27820001001" in urn else "",
             "terms_accepted": "27820001001" in urn,
             "province": "FS",
             "suburb": "cape town",
@@ -218,3 +229,12 @@ async def test_callback_check_response_to_handler(
     tester.assert_num_messages(1)
 
     assert len(rapidpro_mock.app.requests) == 2
+
+
+@pytest.mark.asyncio
+async def test_aaq_timeout_response_to_handler(tester: AppTester, rapidpro_mock):
+    await tester.user_input(session=Message.SESSION_EVENT.NEW, content="no")
+    tester.assert_num_messages(1)
+    tester.assert_message("TODO: Handle question not answered")
+
+    assert len(rapidpro_mock.app.requests) == 3


### PR DESCRIPTION
Review and merge https://github.com/praekeltfoundation/vaccine-eligibility/pull/278 first.


This adds a step to schedule a timeout message 5min after we offer the user answer topics to their question

This also adds the functionality to determine if an inbound message might be a response to one of these timeouts and handles it as such
[Miro board](https://miro.com/app/board/uXjVO9B3_Ek=/?moveToWidget=3458764528783874521&cot=14)