### PR TITLE
Get and send suggested content to Rapidpro

### DIFF
--- a/yal/contentrepo.py
+++ b/yal/contentrepo.py
@@ -52,6 +52,12 @@ async def get_choices_by_id(page_id):
     return await get_choices_by_path(f"/api/v2/pages?id={page_id}")
 
 
+async def get_suggested_choices(topics_viewed):
+    return await get_choices_by_path(
+        f"/suggestedcontent/?topics_viewed={','.join(topics_viewed)}"
+    )
+
+
 async def get_page_detail_by_tag(user, tag):
     error, choices = await get_choices_by_path(f"/api/v2/pages?tag={tag}")
 

--- a/yal/tests/test_main.py
+++ b/yal/tests/test_main.py
@@ -133,6 +133,16 @@ async def contentrepo_api_mock(sanic_client):
             }
         )
 
+    @app.route("/suggestedcontent", methods=["GET"])
+    def get_suggested_content(request):
+        app.requests.append(request)
+        return response.json(
+            {
+                "count": 1,
+                "results": [{"id": 311, "title": "Suggested Content 1"}],
+            }
+        )
+
     client = await sanic_client(app)
     url = config.CONTENTREPO_API_URL
     config.CONTENTREPO_API_URL = f"http://{client.host}:{client.port}"
@@ -147,8 +157,8 @@ async def test_reset_keyword(tester: AppTester, rapidpro_mock, contentrepo_api_m
     tester.assert_state("state_mainmenu")
     tester.assert_num_messages(1)
 
-    assert len(rapidpro_mock.app.requests) == 1
-    assert len(contentrepo_api_mock.app.requests) == 2
+    assert len(rapidpro_mock.app.requests) == 2
+    assert len(contentrepo_api_mock.app.requests) == 3
 
 
 @pytest.mark.asyncio
@@ -189,8 +199,8 @@ async def test_state_start_to_mainmenu(
     tester.assert_state("state_mainmenu")
     tester.assert_num_messages(1)
 
-    assert len(rapidpro_mock.app.requests) == 1
-    assert len(contentrepo_api_mock.app.requests) == 2
+    assert len(rapidpro_mock.app.requests) == 2
+    assert len(contentrepo_api_mock.app.requests) == 3
 
     tester.assert_metadata("province", "FS")
     tester.assert_metadata("suburb", "cape town")


### PR DESCRIPTION
We gather the suggested content and save it on the Rapidpro Contact to send after 15 minutes of no response.

The choices are added to the state but not displayed so they'll still work after the user gets the suggested content options from rapidpro