### PR TITLE
Fix DeprecationWarnings by not setting variables on Sanic instances

### DIFF
--- a/mqr/tests/test_baseline_ussd.py
+++ b/mqr/tests/test_baseline_ussd.py
@@ -937,7 +937,9 @@ async def test_state_education_level_submit(rapidpro_mock, eventstore_mock):
         "education_level": "less_grade_7",
     }
 
-    assert [r.path for r in rapidpro_mock.tstate.requests] == ["/api/v2/flow_starts.json"]
+    assert [r.path for r in rapidpro_mock.tstate.requests] == [
+        "/api/v2/flow_starts.json"
+    ]
     request = rapidpro_mock.tstate.requests[0]
     assert json.loads(request.body.decode("utf-8")) == {
         "flow": config.RAPIDPRO_BASELINE_SURVEY_COMPLETE_FLOW,

--- a/mqr/tests/test_midline_ussd.py
+++ b/mqr/tests/test_midline_ussd.py
@@ -984,7 +984,9 @@ async def test_state_likelihood_of_following_schedule_valid(
     await tester.user_input("1")
     tester.assert_state("state_eat_fruits")
 
-    assert [r.path for r in rapidpro_mock.tstate.requests] == ["/api/v2/flow_starts.json"]
+    assert [r.path for r in rapidpro_mock.tstate.requests] == [
+        "/api/v2/flow_starts.json"
+    ]
     request = rapidpro_mock.tstate.requests[0]
     assert json.loads(request.body.decode("utf-8")) == {
         "flow": config.RAPIDPRO_MIDLINE_SURVEY_COMPLETE_FLOW,

--- a/mqr/tests/test_midline_ussd.py
+++ b/mqr/tests/test_midline_ussd.py
@@ -6,7 +6,7 @@ from sanic import Sanic, response
 from mqr import config
 from mqr.midline_ussd import Application
 from vaccine.models import Message
-from vaccine.testing import AppTester
+from vaccine.testing import AppTester, TState
 
 
 @pytest.fixture
@@ -18,19 +18,18 @@ def tester():
 async def rapidpro_mock(sanic_client):
     Sanic.test_mode = True
     app = Sanic("mock_rapidpro")
-    app.requests = []
-    app.errors = 0
-    app.errormax = 0
+    tstate = TState()
 
     @app.route("/api/v2/flow_starts.json", methods=["POST"])
     def start_flow(request):
-        app.requests.append(request)
+        tstate.requests.append(request)
         return response.json({}, status=200)
 
     client = await sanic_client(app)
     url = config.RAPIDPRO_URL
     config.RAPIDPRO_URL = f"http://{client.host}:{client.port}"
     config.RAPIDPRO_TOKEN = "testtoken"
+    client.tstate = tstate
     yield client
     config.RAPIDPRO_URL = url
 
@@ -985,8 +984,8 @@ async def test_state_likelihood_of_following_schedule_valid(
     await tester.user_input("1")
     tester.assert_state("state_eat_fruits")
 
-    assert [r.path for r in rapidpro_mock.app.requests] == ["/api/v2/flow_starts.json"]
-    request = rapidpro_mock.app.requests[0]
+    assert [r.path for r in rapidpro_mock.tstate.requests] == ["/api/v2/flow_starts.json"]
+    request = rapidpro_mock.tstate.requests[0]
     assert json.loads(request.body.decode("utf-8")) == {
         "flow": config.RAPIDPRO_MIDLINE_SURVEY_COMPLETE_FLOW,
         "urns": ["whatsapp:27820001001"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,4 +57,4 @@ profile = "black"
 multi_line_output = 3
 
 [tool.pytest.ini_options]
-addopts = "--cov=vaccine --cov=yal"
+addopts = "--cov=vaccine --cov=yal -W error::DeprecationWarning"

--- a/vaccine/main.py
+++ b/vaccine/main.py
@@ -25,19 +25,19 @@ setup_metrics_middleware(app)
 
 @app.before_server_start
 async def setup_worker(app, loop):
-    app.worker = Worker()
-    await app.worker.setup()
+    app.ctx.worker = Worker()
+    await app.ctx.worker.setup()
 
 
 @app.after_server_stop
 async def shutdown_worker(app, loop):
-    await app.worker.teardown()
+    await app.ctx.worker.teardown()
 
 
 @app.route("/")
 async def health(request: Request) -> HTTPResponse:
     result: dict = {"status": "ok", "amqp": {}, "redis": {}}
-    worker: Worker = app.worker  # type: ignore
+    worker: Worker = app.ctx.worker  # type: ignore
 
     if worker.connection.connection is None:  # pragma: no cover
         result["amqp"]["connection"] = False

--- a/vaccine/testing.py
+++ b/vaccine/testing.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass, field
 from typing import Any, Callable, List, Optional, Type
 
 from aio_pika import IncomingMessage
@@ -177,3 +178,10 @@ class FakeWorker(Worker):
 
     async def process_event(self, amqp_msg: IncomingMessage):
         self.events.append(amqp_msg)
+
+
+@dataclass
+class TState:
+    requests: list = field(default_factory=list)
+    errors: int = 0
+    errormax: int = 0

--- a/vaccine/tests/test_healthcheck_ussd.py
+++ b/vaccine/tests/test_healthcheck_ussd.py
@@ -494,7 +494,9 @@ async def test_state_privacy_policy(rapidpro_mock):
         ]
     )
 
-    assert [r.path for r in rapidpro_mock.tstate.requests] == ["/api/v2/flow_starts.json"]
+    assert [r.path for r in rapidpro_mock.tstate.requests] == [
+        "/api/v2/flow_starts.json"
+    ]
     assert [r.json for r in rapidpro_mock.tstate.requests] == [
         {"flow": "flow-uuid", "urns": ["tel:27820001003"]}
     ]
@@ -1570,7 +1572,9 @@ async def test_state_tracing(eventstore_mock):
 
     assert u.state.name == "state_start"
 
-    assert [r.path for r in eventstore_mock.tstate.requests] == ["/api/v3/covid19triage/"]
+    assert [r.path for r in eventstore_mock.tstate.requests] == [
+        "/api/v3/covid19triage/"
+    ]
 
     app = Application(get_user({"state_exposure": "yes"}))
     [reply] = await app.process_message(get_message("yes"))

--- a/vaccine/tests/test_vaccine_cert.py
+++ b/vaccine/tests/test_vaccine_cert.py
@@ -15,11 +15,9 @@ def tester():
 async def whatsapp_mock(sanic_client, tester):
     Sanic.test_mode = True
     app = Sanic("mock_whatsapp")
-    app.requests = []
 
     @app.route("/v1/media/<media_id>", methods=["GET"])
     def valid_registration(request, media_id):
-        app.requests.append(request)
         return response.file(f"vaccine/data/{media_id}")
 
     client = await sanic_client(app)

--- a/yal/tests/test_askaquestion.py
+++ b/yal/tests/test_askaquestion.py
@@ -6,7 +6,7 @@ import pytest
 from sanic import Sanic, response
 
 from vaccine.models import Message
-from vaccine.testing import AppTester
+from vaccine.testing import AppTester, TState
 from yal import config
 from yal.main import Application
 from yal.utils import BACK_TO_MAIN
@@ -57,29 +57,30 @@ def get_aaq_response(answers, next=None, prev=None):
 async def aaq_mock(sanic_client):
     Sanic.test_mode = True
     app = Sanic("mock_aaq")
-    app.requests = []
+    tstate = TState()
 
     @app.route("/inbound/check", methods=["POST"])
     def inbound_check(request):
-        app.requests.append(request)
+        tstate.requests.append(request)
         body = get_aaq_response(MODEL_ANSWERS_PAGE_1, next="/inbound/92567/1")
         return response.json(body, status=200)
 
     @app.route("/inbound/92567/1", methods=["GET"])
     def inbound_check_page_2(request):
-        app.requests.append(request)
+        tstate.requests.append(request)
         body = get_aaq_response(MODEL_ANSWERS_PAGE_2, prev="/inbound/92567/0")
         return response.json(body, status=200)
 
     @app.route("/inbound/feedback", methods=["PUT"])
     def add_feedback(request):
-        app.requests.append(request)
+        tstate.requests.append(request)
         return response.json({}, status=200)
 
     client = await sanic_client(app)
     url = config.AAQ_URL
     config.AAQ_URL = f"http://{client.host}:{client.port}"
     config.AAQ_TOKEN = "testtoken"
+    client.tstate = tstate
     yield client
     config.AAQ_URL = url
 
@@ -88,11 +89,11 @@ async def aaq_mock(sanic_client):
 async def rapidpro_mock(sanic_client):
     Sanic.test_mode = True
     app = Sanic("mock_rapidpro")
-    app.requests = []
+    tstate = TState()
 
     @app.route("/api/v2/contacts.json", methods=["GET"])
     def get_contact(request):
-        app.requests.append(request)
+        tstate.requests.append(request)
 
         urn = request.args.get("urn")
         contacts = [get_rapidpro_contact(urn)]
@@ -107,13 +108,14 @@ async def rapidpro_mock(sanic_client):
 
     @app.route("/api/v2/contacts.json", methods=["POST"])
     def update_contact(request):
-        app.requests.append(request)
+        tstate.requests.append(request)
         return response.json({}, status=200)
 
     client = await sanic_client(app)
     url = config.RAPIDPRO_URL
     config.RAPIDPRO_URL = f"http://{client.host}:{client.port}"
     config.RAPIDPRO_TOKEN = "testtoken"
+    client.tstate = tstate
     yield client
     config.RAPIDPRO_URL = url
 
@@ -170,16 +172,16 @@ async def test_start_state_response_sets_timeout(
 
     tester.assert_state("state_display_results")
 
-    assert len(rapidpro_mock.app.requests) == 1
-    request = rapidpro_mock.app.requests[0]
+    assert len(rapidpro_mock.tstate.requests) == 1
+    request = rapidpro_mock.tstate.requests[0]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "next_aaq_timeout_time": "2022-06-19T17:35:00",
             "aaq_timeout_type": "1",
         },
     }
-    assert len(aaq_mock.app.requests) == 1
-    request = aaq_mock.app.requests[0].json
+    assert len(aaq_mock.tstate.requests) == 1
+    request = aaq_mock.tstate.requests[0].json
     request["metadata"].pop("message_id")
     request["metadata"].pop("session_id")
     assert request == {
@@ -233,8 +235,8 @@ async def test_state_display_results_choose_an_answer(
 
     tester.assert_state("state_get_content_feedback")
 
-    assert len(rapidpro_mock.app.requests) == 1
-    request = rapidpro_mock.app.requests[0]
+    assert len(rapidpro_mock.tstate.requests) == 1
+    request = rapidpro_mock.tstate.requests[0]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "next_aaq_timeout_time": "2022-06-19T17:35:00",
@@ -337,14 +339,14 @@ async def test_state_get_content_feedback_question_answered(
 
     tester.assert_state("state_start")
 
-    assert len(rapidpro_mock.app.requests) == 1
-    request = rapidpro_mock.app.requests[0]
+    assert len(rapidpro_mock.tstate.requests) == 1
+    request = rapidpro_mock.tstate.requests[0]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {"aaq_timeout_type": ""},
     }
 
-    assert len(aaq_mock.app.requests) == 1
-    request = aaq_mock.app.requests[0]
+    assert len(aaq_mock.tstate.requests) == 1
+    request = aaq_mock.tstate.requests[0]
     assert json.loads(request.body.decode("utf-8")) == {
         "feedback": {"feedback_type": "positive"},
         "feedback_secret_key": "feedback-secret-key",
@@ -372,14 +374,14 @@ async def test_state_display_content_question_not_answered(
 
     tester.assert_state("state_start")
 
-    assert len(rapidpro_mock.app.requests) == 1
-    request = rapidpro_mock.app.requests[0]
+    assert len(rapidpro_mock.tstate.requests) == 1
+    request = rapidpro_mock.tstate.requests[0]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {"aaq_timeout_type": ""},
     }
 
-    assert len(aaq_mock.app.requests) == 1
-    request = aaq_mock.app.requests[0]
+    assert len(aaq_mock.tstate.requests) == 1
+    request = aaq_mock.tstate.requests[0]
     assert json.loads(request.body.decode("utf-8")) == {
         "feedback": {"feedback_type": "negative"},
         "feedback_secret_key": "feedback-secret-key",
@@ -399,8 +401,8 @@ async def test_state_handle_timeout_handles_type_1_yes(
     tester.setup_state("state_handle_timeout_response")
     await tester.user_input(session=Message.SESSION_EVENT.NEW, content="yes ask again")
 
-    assert len(rapidpro_mock.app.requests) == 2
-    request = rapidpro_mock.app.requests[1]
+    assert len(rapidpro_mock.tstate.requests) == 2
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {"aaq_timeout_sent": "", "aaq_timeout_type": ""},
     }
@@ -413,8 +415,8 @@ async def test_state_handle_timeout_handles_type_1_no(tester: AppTester, rapidpr
     tester.setup_state("state_handle_timeout_response")
     await tester.user_input(session=Message.SESSION_EVENT.NEW, content="no, I'm good")
 
-    assert len(rapidpro_mock.app.requests) == 2
-    request = rapidpro_mock.app.requests[1]
+    assert len(rapidpro_mock.tstate.requests) == 2
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {"aaq_timeout_sent": "", "aaq_timeout_type": ""},
     }
@@ -430,8 +432,8 @@ async def test_state_handle_timeout_handles_type_2_yes(
     tester.setup_state("state_handle_timeout_response")
     await tester.user_input(session=Message.SESSION_EVENT.NEW, content="yes")
 
-    assert len(rapidpro_mock.app.requests) == 2
-    request = rapidpro_mock.app.requests[1]
+    assert len(rapidpro_mock.tstate.requests) == 2
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {"aaq_timeout_sent": "", "aaq_timeout_type": ""},
     }
@@ -451,8 +453,8 @@ async def test_state_handle_timeout_handles_type_2_no(tester: AppTester, rapidpr
     tester.setup_state("state_handle_timeout_response")
     await tester.user_input(session=Message.SESSION_EVENT.NEW, content="no")
 
-    assert len(rapidpro_mock.app.requests) == 2
-    request = rapidpro_mock.app.requests[1]
+    assert len(rapidpro_mock.tstate.requests) == 2
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {"aaq_timeout_sent": "", "aaq_timeout_type": ""},
     }

--- a/yal/tests/test_mainmenu.py
+++ b/yal/tests/test_mainmenu.py
@@ -8,7 +8,7 @@ import pytest
 from sanic import Sanic, response
 
 from vaccine.models import Message
-from vaccine.testing import AppTester
+from vaccine.testing import AppTester, TState
 from yal import config, turn
 from yal.main import Application
 from yal.utils import BACK_TO_MAIN, GET_HELP
@@ -58,17 +58,18 @@ def build_message_detail(
 async def rapidpro_mock(sanic_client):
     Sanic.test_mode = True
     app = Sanic("mock_rapidpro")
-    app.requests = []
+    tstate = TState()
 
     @app.route("/api/v2/contacts.json", methods=["POST"])
     def update_contact(request):
-        app.requests.append(request)
+        tstate.requests.append(request)
         return response.json({}, status=200)
 
     client = await sanic_client(app)
     url = config.RAPIDPRO_URL
     config.RAPIDPRO_URL = f"http://{client.host}:{client.port}"
     config.RAPIDPRO_TOKEN = "testtoken"
+    client.tstate = tstate
     yield client
     config.RAPIDPRO_URL = url
 
@@ -77,17 +78,18 @@ async def rapidpro_mock(sanic_client):
 async def turn_mock(sanic_client):
     Sanic.test_mode = True
     app = Sanic("mock_turn")
-    app.requests = []
+    tstate = TState()
 
     @app.route("/v1/messages/<message_id:string>/labels", methods=["POST"])
     def label_message(request, message_id):
-        app.requests.append(request)
+        tstate.requests.append(request)
         return response.json({}, status=200)
 
     client = await sanic_client(app)
 
     get_turn_url = turn.get_turn_url
     turn.get_turn_url = lambda path: f"http://{client.host}:{client.port}/{path}"
+    client.tstate = tstate
     yield client
     turn.get_turn_url = get_turn_url
 
@@ -96,16 +98,14 @@ async def turn_mock(sanic_client):
 async def contentrepo_api_mock(sanic_client):
     Sanic.test_mode = True
     app = Sanic("contentrepo_api_mock")
-    app.requests = []
-    app.errors = 0
-    app.errormax = 0
+    tstate = TState()
 
     @app.route("/api/v2/pages", methods=["GET"])
     def get_main_menu(request):
-        app.requests.append(request)
-        if app.errormax:
-            if app.errors < app.errormax:
-                app.errors += 1
+        tstate.requests.append(request)
+        if tstate.errormax:
+            if tstate.errors < tstate.errormax:
+                tstate.errors += 1
                 return response.json({}, status=500)
 
         tag = request.args.get("tag")
@@ -138,7 +138,7 @@ async def contentrepo_api_mock(sanic_client):
 
     @app.route("/suggestedcontent", methods=["GET"])
     def get_suggested_content(request):
-        app.requests.append(request)
+        tstate.requests.append(request)
         pages = []
         pages.append({"id": 444, "title": "Suggested Content 1"})
         pages.append({"id": 555, "title": "Suggested Content 2"})
@@ -152,7 +152,7 @@ async def contentrepo_api_mock(sanic_client):
 
     @app.route("/api/v2/pages/111", methods=["GET"])
     def get_page_detail_111(request):
-        app.requests.append(request)
+        tstate.requests.append(request)
         return response.json(
             build_message_detail(
                 111,
@@ -163,7 +163,7 @@ async def contentrepo_api_mock(sanic_client):
 
     @app.route("/api/v2/pages/1111", methods=["GET"])
     def get_page_detail_1111(request):
-        app.requests.append(request)
+        tstate.requests.append(request)
         return response.json(
             build_message_detail(
                 111,
@@ -174,7 +174,7 @@ async def contentrepo_api_mock(sanic_client):
 
     @app.route("/api/v2/pages/1112", methods=["GET"])
     def get_page_detail_1112(request):
-        app.requests.append(request)
+        tstate.requests.append(request)
         return response.json(
             build_message_detail(
                 1112,
@@ -186,7 +186,7 @@ async def contentrepo_api_mock(sanic_client):
 
     @app.route("/api/v2/pages/222", methods=["GET"])
     def get_page_detail_222(request):
-        app.requests.append(request)
+        tstate.requests.append(request)
         return response.json(
             build_message_detail(
                 222,
@@ -198,7 +198,7 @@ async def contentrepo_api_mock(sanic_client):
 
     @app.route("/api/v2/pages/333", methods=["GET"])
     def get_page_detail_333(request):
-        app.requests.append(request)
+        tstate.requests.append(request)
         return response.json(
             build_message_detail(
                 333,
@@ -210,7 +210,7 @@ async def contentrepo_api_mock(sanic_client):
 
     @app.route("/api/v2/pages/444", methods=["GET"])
     def get_page_detail_444(request):
-        app.requests.append(request)
+        tstate.requests.append(request)
         return response.json(
             build_message_detail(
                 444,
@@ -221,7 +221,7 @@ async def contentrepo_api_mock(sanic_client):
 
     @app.route("/api/v2/pages/1231", methods=["GET"])
     def get_page_detail_1231(request):
-        app.requests.append(request)
+        tstate.requests.append(request)
         return response.json(
             build_message_detail(
                 444,
@@ -235,7 +235,7 @@ async def contentrepo_api_mock(sanic_client):
 
     @app.route("/api/v2/pages/1232", methods=["GET"])
     def get_page_detail_1232(request):
-        app.requests.append(request)
+        tstate.requests.append(request)
         return response.json(
             build_message_detail(
                 444,
@@ -248,7 +248,7 @@ async def contentrepo_api_mock(sanic_client):
 
     @app.route("/api/v2/pages/1234", methods=["GET"])
     def get_page_detail_1234(request):
-        app.requests.append(request)
+        tstate.requests.append(request)
         return response.json(
             build_message_detail(
                 1234,
@@ -260,7 +260,7 @@ async def contentrepo_api_mock(sanic_client):
 
     @app.route("/api/v2/pages/1235", methods=["GET"])
     def get_page_detail_1235(request):
-        app.requests.append(request)
+        tstate.requests.append(request)
         return response.json(
             build_message_detail(
                 1235,
@@ -272,7 +272,7 @@ async def contentrepo_api_mock(sanic_client):
 
     @app.route("/api/v2/pages/1236", methods=["GET"])
     def get_page_detail_1236(request):
-        app.requests.append(request)
+        tstate.requests.append(request)
         return response.json(
             build_message_detail(
                 1236,
@@ -284,20 +284,21 @@ async def contentrepo_api_mock(sanic_client):
 
     @app.route("/api/v2/images/<image_id:int>", methods=["GET"])
     def get_image(request, image_id):
-        app.requests.append(request)
+        tstate.requests.append(request)
         return response.json(
             {"meta": {"download_url": f"http://aws.test/test{image_id}.jpg"}}
         )
 
     @app.route("/api/v2/custom/ratings/", methods=["POST"])
     def add_page_rating(request):
-        app.requests.append(request)
+        tstate.requests.append(request)
         return response.json({}, status=201)
 
     client = await sanic_client(app)
     url = config.CONTENTREPO_API_URL
     config.CONTENTREPO_API_URL = f"http://{client.host}:{client.port}"
     config.CONTENTREPO_API_TOKEN = "testtoken"
+    client.tstate = tstate
     yield client
     config.CONTENTREPO_API_URL = url
 
@@ -344,15 +345,15 @@ async def test_state_mainmenu_start(
         )
     )
 
-    assert [r.path for r in contentrepo_api_mock.app.requests] == [
+    assert [r.path for r in contentrepo_api_mock.tstate.requests] == [
         "/api/v2/pages",
         "/api/v2/pages",
         "/api/v2/pages",
         "/suggestedcontent/",
     ]
 
-    assert len(rapidpro_mock.app.requests) == 1
-    request = rapidpro_mock.app.requests[0]
+    assert len(rapidpro_mock.tstate.requests) == 1
+    request = rapidpro_mock.tstate.requests[0]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "last_mainmenu_time": "2022-06-19T17:30:00",
@@ -407,14 +408,14 @@ async def test_state_mainmenu_start_suggested_populated(
         )
     )
 
-    assert [r.path for r in contentrepo_api_mock.app.requests] == [
+    assert [r.path for r in contentrepo_api_mock.tstate.requests] == [
         "/api/v2/pages",
         "/api/v2/pages",
         "/api/v2/pages",
     ]
 
-    assert len(rapidpro_mock.app.requests) == 1
-    request = rapidpro_mock.app.requests[0]
+    assert len(rapidpro_mock.tstate.requests) == 1
+    request = rapidpro_mock.tstate.requests[0]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "last_mainmenu_time": "2022-06-19T17:30:00",
@@ -433,14 +434,14 @@ async def test_state_mainmenu_static(
     tester.assert_num_messages(1)
     tester.assert_state("state_servicefinder_start")
 
-    assert [r.path for r in contentrepo_api_mock.app.requests] == [
+    assert [r.path for r in contentrepo_api_mock.tstate.requests] == [
         "/api/v2/pages",
         "/api/v2/pages",
         "/api/v2/pages",
         "/suggestedcontent/",
     ]
 
-    assert len(rapidpro_mock.app.requests) == 2
+    assert len(rapidpro_mock.tstate.requests) == 2
 
 
 @pytest.mark.asyncio
@@ -454,14 +455,14 @@ async def test_state_mainmenu_aaq(
     tester.assert_state("state_start")
     tester.assert_message("Coming soon...")
 
-    assert [r.path for r in contentrepo_api_mock.app.requests] == [
+    assert [r.path for r in contentrepo_api_mock.tstate.requests] == [
         "/api/v2/pages",
         "/api/v2/pages",
         "/api/v2/pages",
         "/suggestedcontent/",
     ]
 
-    assert len(rapidpro_mock.app.requests) == 2
+    assert len(rapidpro_mock.tstate.requests) == 2
 
 
 @pytest.mark.asyncio
@@ -490,7 +491,7 @@ async def test_state_mainmenu_contentrepo(
     tester.assert_num_messages(1)
     tester.assert_message(question)
 
-    assert [r.path for r in contentrepo_api_mock.app.requests] == [
+    assert [r.path for r in contentrepo_api_mock.tstate.requests] == [
         "/api/v2/pages",
         "/api/v2/pages",
         "/api/v2/pages",
@@ -500,8 +501,8 @@ async def test_state_mainmenu_contentrepo(
 
     tester.assert_metadata("topics_viewed", ["222"])
 
-    assert len(rapidpro_mock.app.requests) == 3
-    request = rapidpro_mock.app.requests[1]
+    assert len(rapidpro_mock.tstate.requests) == 3
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "last_mainmenu_time": "",
@@ -562,7 +563,7 @@ async def test_state_mainmenu_contentrepo_children(
     tester.assert_num_messages(1)
     tester.assert_message(question)
 
-    assert [r.path for r in contentrepo_api_mock.app.requests] == [
+    assert [r.path for r in contentrepo_api_mock.tstate.requests] == [
         "/api/v2/pages",
         "/api/v2/pages",
         "/api/v2/pages",
@@ -573,7 +574,7 @@ async def test_state_mainmenu_contentrepo_children(
         "/api/v2/pages/444",
     ]
 
-    detail_request = contentrepo_api_mock.app.requests[-1]
+    detail_request = contentrepo_api_mock.tstate.requests[-1]
     parsed_url = urlparse(detail_request.url)
     params = parse_qs(parsed_url.query)
 
@@ -581,9 +582,9 @@ async def test_state_mainmenu_contentrepo_children(
     assert params["data__session_id"][0] == "1"
     assert params["data__user_addr"][0] == "27820001001"
 
-    assert len(rapidpro_mock.app.requests) == 5
+    assert len(rapidpro_mock.tstate.requests) == 5
 
-    update_request = rapidpro_mock.app.requests[-1]
+    update_request = rapidpro_mock.tstate.requests[-1]
     assert update_request.json["fields"] == {
         "last_main_time": "2022-06-19T17:30:00",
         "suggested_text": "*3* - Suggested Content 1\n*4* - Suggested Content 2",
@@ -1300,7 +1301,7 @@ async def test_state_prompt_not_found_comment(tester: AppTester, turn_mock):
     )
 
     message_id = tester.application.inbound.message_id  # type: ignore
-    label_request = turn_mock.app.requests[0]
+    label_request = turn_mock.tstate.requests[0]
     assert label_request.path == f"/v1/messages/{message_id}/labels"
     assert json.loads(label_request.body.decode("utf-8")) == {
         "labels": ["Priority Question"],
@@ -1348,7 +1349,7 @@ async def test_state_prompt_info_useful_submit(tester: AppTester, contentrepo_ap
 
     await tester.user_input("1")
 
-    post_request = contentrepo_api_mock.app.requests[0]
+    post_request = contentrepo_api_mock.tstate.requests[0]
     assert post_request.path == "/api/v2/custom/ratings/"
     assert json.loads(post_request.body.decode("utf-8")) == {
         "page": "111",
@@ -1380,7 +1381,7 @@ async def test_state_prompt_feedback_comment_submit(
         "Ok got it. Thank you for the feedback, I'm working on it already👍🏾."
     )
 
-    post_request = contentrepo_api_mock.app.requests[0]
+    post_request = contentrepo_api_mock.tstate.requests[0]
     assert post_request.path == "/api/v2/custom/ratings/"
     assert post_request.headers["authorization"] == "Token testtoken"
     assert json.loads(post_request.body.decode("utf-8")) == {
@@ -1391,7 +1392,7 @@ async def test_state_prompt_feedback_comment_submit(
     }
 
     message_id = tester.application.inbound.message_id  # type: ignore
-    label_request = turn_mock.app.requests[0]
+    label_request = turn_mock.tstate.requests[0]
     assert label_request.path == f"/v1/messages/{message_id}/labels"
     assert json.loads(label_request.body.decode("utf-8")) == {
         "labels": ["Priority Question"],

--- a/yal/tests/test_mainmenu.py
+++ b/yal/tests/test_mainmenu.py
@@ -80,7 +80,7 @@ async def turn_mock(sanic_client):
     app = Sanic("mock_turn")
     tstate = TState()
 
-    @app.route("/v1/messages/<message_id:string>/labels", methods=["POST"])
+    @app.route("/v1/messages/<message_id:str>/labels", methods=["POST"])
     def label_message(request, message_id):
         tstate.requests.append(request)
         return response.json({}, status=200)

--- a/yal/tests/test_optout.py
+++ b/yal/tests/test_optout.py
@@ -10,7 +10,7 @@ import pytest
 from sanic import Sanic, response
 
 # from vaccine.models import Message
-from vaccine.testing import AppTester
+from vaccine.testing import AppTester, TState
 from yal import config
 from yal.main import Application
 
@@ -54,16 +54,14 @@ def get_rapidpro_contact(urn):
 async def rapidpro_mock(sanic_client):
     Sanic.test_mode = True
     app = Sanic("mock_rapidpro")
-    app.requests = []
-    app.errors = 0
-    app.errormax = 0
+    tstate = TState()
 
     @app.route("/api/v2/contacts.json", methods=["GET"])
     def get_contact(request):
-        app.requests.append(request)
-        if app.errormax:
-            if app.errors < app.errormax:
-                app.errors += 1
+        tstate.requests.append(request)
+        if tstate.errormax:
+            if tstate.errors < tstate.errormax:
+                tstate.errors += 1
                 return response.json({}, status=500)
 
         urn = request.args.get("urn")
@@ -79,13 +77,14 @@ async def rapidpro_mock(sanic_client):
 
     @app.route("/api/v2/contacts.json", methods=["POST"])
     def update_contact(request):
-        app.requests.append(request)
+        tstate.requests.append(request)
         return response.json({}, status=200)
 
     client = await sanic_client(app)
     url = config.RAPIDPRO_URL
     config.RAPIDPRO_URL = f"http://{client.host}:{client.port}"
     config.RAPIDPRO_TOKEN = "testtoken"
+    client.tstate = tstate
     yield client
     config.RAPIDPRO_URL = url
 
@@ -179,11 +178,11 @@ async def test_state_optout_stop_notifications(
     await tester.user_input("1")
     tester.assert_state("state_optout_survey")
 
-    assert len(rapidpro_mock.app.requests) == 1
+    assert len(rapidpro_mock.tstate.requests) == 1
 
-    assert [r.path for r in rapidpro_mock.app.requests] == ["/api/v2/contacts.json"]
+    assert [r.path for r in rapidpro_mock.tstate.requests] == ["/api/v2/contacts.json"]
 
-    post_request = rapidpro_mock.app.requests[0]
+    post_request = rapidpro_mock.tstate.requests[0]
     assert json.loads(post_request.body.decode("utf-8")) == {
         "fields": {
             "onboarding_completed": "",
@@ -208,10 +207,10 @@ async def test_state_optout_delete_saved(tester: AppTester, rapidpro_mock):
 
     # Two API calls:
     # Get profile to get old details, update profile
-    assert len(rapidpro_mock.app.requests) == 2
-    assert [r.path for r in rapidpro_mock.app.requests] == ["/api/v2/contacts.json"] * 2
+    assert len(rapidpro_mock.tstate.requests) == 2
+    assert [r.path for r in rapidpro_mock.tstate.requests] == ["/api/v2/contacts.json"] * 2
 
-    post_request = rapidpro_mock.app.requests[1]
+    post_request = rapidpro_mock.tstate.requests[1]
     assert json.loads(post_request.body.decode("utf-8")) == {
         "fields": {
             "dob_year": "",

--- a/yal/tests/test_optout.py
+++ b/yal/tests/test_optout.py
@@ -208,7 +208,9 @@ async def test_state_optout_delete_saved(tester: AppTester, rapidpro_mock):
     # Two API calls:
     # Get profile to get old details, update profile
     assert len(rapidpro_mock.tstate.requests) == 2
-    assert [r.path for r in rapidpro_mock.tstate.requests] == ["/api/v2/contacts.json"] * 2
+    assert [r.path for r in rapidpro_mock.tstate.requests] == [
+        "/api/v2/contacts.json"
+    ] * 2
 
     post_request = rapidpro_mock.tstate.requests[1]
     assert json.loads(post_request.body.decode("utf-8")) == {

--- a/yal/tests/test_quiz.py
+++ b/yal/tests/test_quiz.py
@@ -17,11 +17,9 @@ def tester():
 async def contentrepo_api_mock(sanic_client):
     Sanic.test_mode = True
     app = Sanic("contentrepo_api_mock")
-    app.requests = []
 
     @app.route("/api/v2/pages", methods=["GET"])
     def get_pages(request):
-        app.requests.append(request)
         tag = request.args.get("tag")
 
         pages = []
@@ -46,8 +44,6 @@ async def contentrepo_api_mock(sanic_client):
 
     @app.route("/api/v2/pages/<page_id:int>", methods=["GET"])
     def get_page_detail(request, page_id):
-        app.requests.append(request)
-
         title = "Question 1"
         body = "The body of question 1"
         tags = ["score_1"]


### PR DESCRIPTION
The first commit configures pytest to treat DeprecationWarnings as errors.
Following commits will fix the deprecated behaviour.