### PR TITLE
YAL ContentRepo Banner Messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ profile = "black"
 multi_line_output = 3
 
 [tool.pytest.ini_options]
-addopts = "--cov=vaccine --cov=yal"
+addopts = "--cov=vaccine --cov=yal --ignore=vaccine.testing"
 filterwarnings = [
     "error::UserWarning:_pytest",  # For PytestUnhandledCoroutineWarning
     "error::DeprecationWarning",

--- a/vaccine/states.py
+++ b/vaccine/states.py
@@ -331,8 +331,15 @@ class SectionedChoiceState(ChoiceState):
 
 
 class CustomChoiceState(BaseWhatsAppChoiceState):
-    def __init__(self, *args, button: str = None, **kwargs):
+    def __init__(
+        self,
+        *args,
+        button: str = None,
+        additional_messages: Optional[List[str]] = None,
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
+        self.additional_messages = additional_messages or []
         self.button = button
 
     @property
@@ -354,9 +361,9 @@ class CustomChoiceState(BaseWhatsAppChoiceState):
         return helper_metadata
 
     async def display(self, message):
-        return self.app.send_message(
-            self.question, helper_metadata=self._helper_metadata
-        )
+        self.app.send_message(self.question, helper_metadata=self._helper_metadata)
+        for content in self.additional_messages:
+            self.app.send_message(content)
 
     async def display_error(self, message):
         return self.app.send_message(self.error, helper_metadata=self._helper_metadata)

--- a/vaccine/testing.py
+++ b/vaccine/testing.py
@@ -189,6 +189,7 @@ class TState:
     requests: list = field(default_factory=list)
     errors: int = 0
     errormax: int = 0
+    banner: bool = False
 
 
 def unused_port():

--- a/vaccine/tests/test_worker.py
+++ b/vaccine/tests/test_worker.py
@@ -407,7 +407,7 @@ async def test_answer_worker_push_results_user_error(
     )
 
     # wait for worker to log error
-    for _ in range(10):
+    for _ in range(50):
         if len(flow_results_mock_server.tstate.requests) == 3:
             break
         await sleep(0.1)

--- a/yal/mainmenu.py
+++ b/yal/mainmenu.py
@@ -180,6 +180,17 @@ class Application(BaseApplication):
             )
         )
 
+        # We ignore errors here, because if there's an error they just won't get the
+        # banner, we can still carry on and not go to the error state
+        _, banner_choices = await contentrepo.get_choices_by_tag("banner")
+        banner_messages = []
+        for choice in banner_choices:
+            error, page_details = await contentrepo.get_page_details(
+                self.user, choice.value, self.inbound.message_id
+            )
+            if not error:
+                banner_messages.append(page_details["body"])
+
         return CustomChoiceState(
             self,
             question=question,
@@ -191,6 +202,7 @@ class Application(BaseApplication):
             ),
             choices=choices,
             next=next_,
+            additional_messages=banner_messages,
         )
 
     async def state_contentrepo_page(self):

--- a/yal/optout.py
+++ b/yal/optout.py
@@ -89,7 +89,7 @@ class Application(BaseApplication):
                 ]
             )
         )
-        self.worker.publish_message(self.inbound.reply(msg))
+        await self.worker.publish_message(self.inbound.reply(msg))
         await asyncio.sleep(0.5)
         return await self.go_to_state("state_optout_survey")
 

--- a/yal/tests/conftest.py
+++ b/yal/tests/conftest.py
@@ -1,0 +1,9 @@
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="package")
+def mock_sleep():
+    with mock.patch("asyncio.sleep"):
+        yield

--- a/yal/tests/test_main.py
+++ b/yal/tests/test_main.py
@@ -132,12 +132,15 @@ async def contentrepo_api_mock():
     @app.route("/api/v2/pages", methods=["GET"])
     def get_main_menu(request):
         tstate.requests.append(request)
-        return response.json(
-            {
-                "count": 1,
-                "results": [{"id": 111, "title": "Main Menu 1 💊"}],
-            }
-        )
+        tag = request.args.get("tag")
+        if tag == "mainmenu":
+            return response.json(
+                {
+                    "count": 1,
+                    "results": [{"id": 111, "title": "Main Menu 1 💊"}],
+                }
+            )
+        return response.json({"count": 0, "results": []})
 
     @app.route("/suggestedcontent", methods=["GET"])
     def get_suggested_content(request):
@@ -165,7 +168,7 @@ async def test_reset_keyword(tester: AppTester, rapidpro_mock, contentrepo_api_m
     tester.assert_num_messages(1)
 
     assert len(rapidpro_mock.tstate.requests) == 2
-    assert len(contentrepo_api_mock.tstate.requests) == 3
+    assert len(contentrepo_api_mock.tstate.requests) == 4
 
 
 @pytest.mark.asyncio
@@ -215,7 +218,7 @@ async def test_state_start_to_mainmenu(
     tester.assert_num_messages(1)
 
     assert len(rapidpro_mock.tstate.requests) == 2
-    assert len(contentrepo_api_mock.tstate.requests) == 3
+    assert len(contentrepo_api_mock.tstate.requests) == 4
 
     tester.assert_metadata("province", "FS")
     tester.assert_metadata("suburb", "cape town")

--- a/yal/tests/test_pleasecallme.py
+++ b/yal/tests/test_pleasecallme.py
@@ -505,7 +505,7 @@ async def test_state_callback_response_handles_call_received(
     }
 
     tester.assert_state("state_mainmenu")
-    assert len(contentrepo_api_mock.tstate.requests) == 3
+    assert len(contentrepo_api_mock.tstate.requests) == 4
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
If there are any messages tagged with "banner" in the content repo, we want to send that content as additional messages after the main menu
