### PR TITLE
Fix aaq timeouts

### DIFF
--- a/yal/askaquestion.py
+++ b/yal/askaquestion.py
@@ -462,6 +462,41 @@ class Application(BaseApplication):
             },
         )
 
+    async def state_handle_list_timeout(self):
+        choices = [
+            Choice("yes", self._("Yes, ask again")),
+            Choice("no", self._("No, I'm good")),
+        ]
+        question = self._(
+            "\n".join(
+                [
+                    "[persona_emoji] *Me again!*",
+                    "",
+                    "Doesn't look like you found an answer to the question you asked "
+                    "me recently...",
+                    "",
+                    "*Would you like to ask again or try a different Q?*",
+                    "",
+                    get_display_choices(choices),
+                    "",
+                    "-----",
+                    "*Or reply:*",
+                    BACK_TO_MAIN,
+                    GET_HELP,
+                ]
+            )
+        )
+        return WhatsAppButtonState(
+            self,
+            question=question,
+            choices=choices,
+            error=self._(get_generic_error()),
+            next={
+                "yes": "state_aaq_start",
+                "no": "state_pre_mainmenu",
+            },
+        )
+
     async def state_handle_timeout_response(self):
         msisdn = normalise_phonenumber(self.inbound.from_addr)
         whatsapp_id = msisdn.lstrip(" + ")
@@ -469,26 +504,16 @@ class Application(BaseApplication):
         error, fields = await rapidpro.get_profile(whatsapp_id)
         if error:
             return await self.go_to_state("state_error")
-
         data = {
-            "aaq_timeout_sent": "",
-            "aaq_timeout_type": "",
+            "feedback_survey_sent": "",
         }
         error = await rapidpro.update_profile(whatsapp_id, data)
         if error:
             return await self.go_to_state("state_error")
 
-        timeout_type_sent = fields.get("aaq_timeout_type")
-        inbound = clean_inbound(self.inbound.content)
-        self.save_answer("state_get_content_feedback", inbound)
+        timeout_type_sent = fields.get("feedback_type")
 
-        if timeout_type_sent == "1":
-            if inbound == "yes ask again":
-                return await self.go_to_state("state_aaq_start")
-            return EndState(
-                self,
-                self._("Ok"),
-                next=self.START_STATE,
-            )
-        if timeout_type_sent == "2":
-            return await self.go_to_state("state_is_question_answered")
+        if timeout_type_sent == "ask_a_question":
+            return await self.go_to_state("state_handle_list_timeout")
+        if timeout_type_sent == "ask_a_question_2":
+            return await self.go_to_state("state_get_content_feedback")

--- a/yal/askaquestion.py
+++ b/yal/askaquestion.py
@@ -20,7 +20,6 @@ from yal.servicefinder import Application as ServiceFinderApplication
 from yal.utils import (
     BACK_TO_MAIN,
     GET_HELP,
-    clean_inbound,
     get_current_datetime,
     get_generic_error,
     normalise_phonenumber,
@@ -90,8 +89,8 @@ class Application(BaseApplication):
 
         timeout_time = get_current_datetime() + timedelta(minutes=5)
         data = {
-            "next_aaq_timeout_time": timeout_time.isoformat(),
-            "aaq_timeout_type": "1",
+            "feedback_timestamp": timeout_time.isoformat(),
+            "feedback_type": "ask_a_question",
         }
 
         error = await rapidpro.update_profile(whatsapp_id, data)
@@ -226,8 +225,8 @@ class Application(BaseApplication):
 
         timeout_time = get_current_datetime() + timedelta(minutes=5)
         data = {
-            "next_aaq_timeout_time": timeout_time.isoformat(),
-            "aaq_timeout_type": "2",
+            "feedback_timestamp": timeout_time.isoformat(),
+            "feedback_type": "ask_a_question_2",
         }
 
         error = await rapidpro.update_profile(whatsapp_id, data)
@@ -279,12 +278,11 @@ class Application(BaseApplication):
         )
 
     async def state_is_question_answered(self):
-
         msisdn = normalise_phonenumber(self.inbound.from_addr)
         whatsapp_id = msisdn.lstrip(" + ")
 
         data = {
-            "aaq_timeout_type": "",
+            "feedback_type": "",
         }
 
         error = await rapidpro.update_profile(whatsapp_id, data)

--- a/yal/main.py
+++ b/yal/main.py
@@ -46,6 +46,7 @@ CONTENT_FEEDBACK_KEYWORDS = {
     "yes ask again",
     "no i m good",
     "nope",
+    "no go back to list"
 }
 
 

--- a/yal/main.py
+++ b/yal/main.py
@@ -28,7 +28,6 @@ ONBOARDING_REMINDER_KEYWORDS = {
     "not interested",
 }
 CALLBACK_CHECK_KEYWORDS = {"callback"}
-AAQ_TIMEOUT_KEYWORDS = {"yes", "no", "yes ask again", "no i m good"}
 FEEDBACK_KEYWORDS = {"feedback"}
 CONTENT_FEEDBACK_KEYWORDS = {
     "1",
@@ -43,6 +42,9 @@ CONTENT_FEEDBACK_KEYWORDS = {
     "i knew this before",
     "yes i went",
     "no i didn t go",
+    "no",
+    "yes ask again",
+    "no i m good",
 }
 
 
@@ -112,6 +114,10 @@ class Application(
                 self.state_name = WaFbCrossoverFeedbackApplication.START_STATE
             if feedback_survey_sent and feedback_type == "servicefinder":
                 self.state_name = ServiceFinderFeedbackSurveyApplication.START_STATE
+            if feedback_survey_sent and (
+                feedback_type == "ask_a_question" or feedback_type =="ask_a_question_2"
+            ):
+                self.state_name = AaqApplication.TIMEOUT_RESPONSE_STATE
 
             feedback_survey_sent_2 = fields.get("feedback_survey_sent_2")
             feedback_type_2 = fields.get("feedback_type_2")
@@ -119,16 +125,6 @@ class Application(
                 self.state_name = (
                     ServiceFinderFeedbackSurveyApplication.CALLBACK_2_STATE
                 )
-
-        if keyword in AAQ_TIMEOUT_KEYWORDS:
-            msisdn = utils.normalise_phonenumber(message.from_addr)
-            whatsapp_id = msisdn.lstrip(" + ")
-            error, fields = await rapidpro.get_profile(whatsapp_id)
-            if error:
-                return await self.go_to_state("state_error")
-            aaq_timeout_sent = fields.get("aaq_timeout_sent")
-            if aaq_timeout_sent:
-                return await self.go_to_state(AaqApplication.TIMEOUT_RESPONSE_STATE)
 
         return await super().process_message(message)
 

--- a/yal/main.py
+++ b/yal/main.py
@@ -45,6 +45,7 @@ CONTENT_FEEDBACK_KEYWORDS = {
     "no",
     "yes ask again",
     "no i m good",
+    "nope",
 }
 
 

--- a/yal/main.py
+++ b/yal/main.py
@@ -46,7 +46,7 @@ CONTENT_FEEDBACK_KEYWORDS = {
     "yes ask again",
     "no i m good",
     "nope",
-    "no go back to list"
+    "no go back to list",
 }
 
 

--- a/yal/main.py
+++ b/yal/main.py
@@ -116,7 +116,7 @@ class Application(
             if feedback_survey_sent and feedback_type == "servicefinder":
                 self.state_name = ServiceFinderFeedbackSurveyApplication.START_STATE
             if feedback_survey_sent and (
-                feedback_type == "ask_a_question" or feedback_type =="ask_a_question_2"
+                feedback_type == "ask_a_question" or feedback_type == "ask_a_question_2"
             ):
                 self.state_name = AaqApplication.TIMEOUT_RESPONSE_STATE
 

--- a/yal/tests/test_askaquestion.py
+++ b/yal/tests/test_askaquestion.py
@@ -20,7 +20,9 @@ def tester():
 def get_rapidpro_contact(urn):
     return {
         "fields": {
-            "feedback_type": "ask_a_question" if ("27820001001" in urn) else "ask_a_question_2",
+            "feedback_type": "ask_a_question"
+            if ("27820001001" in urn)
+            else "ask_a_question_2",
         },
     }
 
@@ -178,8 +180,8 @@ async def test_start_state_response_sets_timeout(
     request = rapidpro_mock.tstate.requests[0]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
-            "next_aaq_timeout_time": "2022-06-19T17:35:00",
-            "aaq_timeout_type": "1",
+            "feedback_timestamp": "2022-06-19T17:35:00",
+            "feedback_type": "ask_a_question",
         },
     }
     assert len(aaq_mock.tstate.requests) == 1
@@ -250,8 +252,8 @@ async def test_state_display_results_choose_an_answer(
     request = rapidpro_mock.tstate.requests[0]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
-            "next_aaq_timeout_time": "2022-06-19T17:35:00",
-            "aaq_timeout_type": "2",
+            "feedback_timestamp": "2022-06-19T17:35:00",
+            "feedback_type": "ask_a_question_2",
         },
     }
 
@@ -384,7 +386,7 @@ async def test_state_get_content_feedback_question_answered(
     assert len(rapidpro_mock.tstate.requests) == 2
     request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
-        "fields": {"aaq_timeout_type": ""},
+        "fields": {"feedback_type": ""},
     }
 
     assert len(aaq_mock.tstate.requests) == 1

--- a/yal/tests/test_askaquestion.py
+++ b/yal/tests/test_askaquestion.py
@@ -20,7 +20,7 @@ def tester():
 def get_rapidpro_contact(urn):
     return {
         "fields": {
-            "aaq_timeout_type": "1" if ("27820001001" in urn) else "2",
+            "feedback_type": "ask_a_question" if ("27820001001" in urn) else "ask_a_question_2",
         },
     }
 
@@ -521,12 +521,12 @@ async def test_state_handle_timeout_handles_type_1_yes(
 ):
     mock_config.AAQ_URL = "http://aaq-test.com"
     tester.setup_state("state_handle_timeout_response")
-    await tester.user_input(session=Message.SESSION_EVENT.NEW, content="yes ask again")
+    await tester.user_input("yes, ask again")
 
-    assert len(rapidpro_mock.tstate.requests) == 2
-    request = rapidpro_mock.tstate.requests[1]
+    assert len(rapidpro_mock.tstate.requests) == 3
+    request = rapidpro_mock.tstate.requests[-1]
     assert json.loads(request.body.decode("utf-8")) == {
-        "fields": {"aaq_timeout_sent": "", "aaq_timeout_type": ""},
+        "fields": {"feedback_survey_sent": ""},
     }
 
     tester.assert_state("state_aaq_start")
@@ -535,15 +535,15 @@ async def test_state_handle_timeout_handles_type_1_yes(
 @pytest.mark.asyncio
 async def test_state_handle_timeout_handles_type_1_no(tester: AppTester, rapidpro_mock):
     tester.setup_state("state_handle_timeout_response")
-    await tester.user_input(session=Message.SESSION_EVENT.NEW, content="no, I'm good")
+    await tester.user_input("no, I'm good")
 
-    assert len(rapidpro_mock.tstate.requests) == 2
-    request = rapidpro_mock.tstate.requests[1]
+    assert len(rapidpro_mock.tstate.requests) == 4
+    request = rapidpro_mock.tstate.requests[2]
     assert json.loads(request.body.decode("utf-8")) == {
-        "fields": {"aaq_timeout_sent": "", "aaq_timeout_type": ""},
+        "fields": {"feedback_survey_sent": ""},
     }
 
-    tester.assert_state("state_start")
+    tester.assert_state("state_mainmenu")
 
 
 @pytest.mark.asyncio
@@ -557,12 +557,12 @@ async def test_state_handle_timeout_handles_type_2_yes(
     tester.user.metadata["faq_id"] = "1"
     tester.user.metadata["model_answers"] = MODEL_ANSWERS_PAGE_1
     tester.user.metadata["aaq_page"] = 0
-    await tester.user_input(session=Message.SESSION_EVENT.NEW, content="yes")
+    await tester.user_input(content="yes")
 
     assert len(rapidpro_mock.tstate.requests) == 4
     request = rapidpro_mock.tstate.requests[2]
     assert json.loads(request.body.decode("utf-8")) == {
-        "fields": {"aaq_timeout_sent": "", "aaq_timeout_type": ""},
+        "fields": {"feedback_survey_sent": ""},
     }
 
     tester.assert_state("state_yes_question_answered")
@@ -606,12 +606,12 @@ async def test_state_handle_timeout_handles_type_2_no(
     tester.user.metadata["faq_id"] = "1"
     tester.user.metadata["model_answers"] = MODEL_ANSWERS_PAGE_1
     tester.user.metadata["aaq_page"] = 0
-    await tester.user_input(session=Message.SESSION_EVENT.NEW, content="no")
+    await tester.user_input(content="nope...")
 
-    assert len(rapidpro_mock.tstate.requests) == 3
-    request = rapidpro_mock.tstate.requests[1]
+    assert len(rapidpro_mock.tstate.requests) == 4
+    request = rapidpro_mock.tstate.requests[2]
     assert json.loads(request.body.decode("utf-8")) == {
-        "fields": {"aaq_timeout_sent": "", "aaq_timeout_type": ""},
+        "fields": {"feedback_survey_sent": ""},
     }
 
     tester.assert_state("state_no_question_not_answered")

--- a/yal/tests/test_change_preferences.py
+++ b/yal/tests/test_change_preferences.py
@@ -272,7 +272,7 @@ async def test_state_update_gender_confirm_not_correct(
     tester.assert_state("state_update_gender")
     tester.assert_num_messages(1)
 
-    assert [r.path for r in rapidpro_mock.tstate.requests] == []
+    assert [r.path for r in rapidpro_mock.tstate.requests] == ["/api/v2/contacts.json"]
 
 
 @pytest.mark.asyncio
@@ -331,7 +331,7 @@ async def test_state_update_age_confirm_not_correct(tester: AppTester, rapidpro_
     tester.assert_num_messages(1)
     tester.assert_state("state_update_age")
 
-    assert [r.path for r in rapidpro_mock.tstate.requests] == []
+    assert [r.path for r in rapidpro_mock.tstate.requests] == ["/api/v2/contacts.json"]
 
 
 @pytest.mark.asyncio
@@ -394,7 +394,7 @@ async def test_state_update_relationship_status_confirm_not_correct(
     tester.assert_num_messages(1)
     tester.assert_state("state_update_relationship_status")
 
-    assert [r.path for r in rapidpro_mock.tstate.requests] == []
+    assert [r.path for r in rapidpro_mock.tstate.requests] == ["/api/v2/contacts.json"]
 
 
 @pytest.mark.asyncio
@@ -614,7 +614,7 @@ async def test_state_update_location_skip(
 
 @pytest.mark.asyncio
 async def test_state_update_location_confirm_incorrect(
-    tester: AppTester, google_api_mock
+    tester: AppTester, google_api_mock, rapidpro_mock
 ):
     tester.user.metadata["latitude"] = 56.78
     tester.user.metadata["longitude"] = 12.34

--- a/yal/tests/test_main.py
+++ b/yal/tests/test_main.py
@@ -86,6 +86,10 @@ def get_rapidpro_contact(urn):
         feedback_type_2 = "servicefinder"
         feedback_timestamp_2 = "2022-03-04T05:06:07"
         feedback_survey_sent_2 = "true"
+    if "27820001006" in urn:
+        feedback_type = "ask_a_question"
+    if "27820001007" in urn:
+        feedback_type = "ask_a_question_2"
     return {
         "uuid": "b733e997-b0b4-4d4d-a3ad-0546e1644aa9",
         "name": "",
@@ -94,8 +98,6 @@ def get_rapidpro_contact(urn):
         "fields": {
             "onboarding_completed": "27820001001" in urn,
             "onboarding_reminder_sent": "27820001001" in urn,
-            "aaq_timeout_sent": "27820001001" in urn,
-            "aaq_timeout_type": "2" if "27820001001" in urn else "",
             "terms_accepted": "27820001001" in urn,
             "province": "FS",
             "suburb": "cape town",
@@ -345,12 +347,13 @@ async def test_callback_check_response_to_handler(tester: AppTester):
 async def test_aaq_timeout_response_to_handler(
     tester: AppTester, rapidpro_mock, aaq_mock
 ):
+    tester.setup_user_address("27820001007")
     tester.user.metadata["inbound_id"] = "inbound-id"
     tester.user.metadata["feedback_secret_key"] = "feedback-secret-key"
     tester.user.metadata["faq_id"] = "1"
     tester.user.metadata["model_answers"] = MODEL_ANSWERS_PAGE_1
     tester.user.metadata["aaq_page"] = 0
-    await tester.user_input(session=Message.SESSION_EVENT.NEW, content="no")
+    await tester.user_input("Nope...")
     tester.assert_state("state_no_question_not_answered")
     tester.assert_num_messages(1)
     message = "\n".join(

--- a/yal/tests/test_mainmenu.py
+++ b/yal/tests/test_mainmenu.py
@@ -1607,7 +1607,7 @@ async def test_state_prompt_info_found(tester: AppTester):
 
 
 @pytest.mark.asyncio
-async def test_state_prompt_info_found_no(tester: AppTester):
+async def test_state_prompt_info_found_no(tester: AppTester, rapidpro_mock):
     tester.setup_state("state_prompt_info_found")
     await tester.user_input("no")
 


### PR DESCRIPTION
The AAQ feedback flow was being triggered from the start state but we'll generally expect this flow to be stared from an existing session.
Also we should use the shared feedback contact fields for these reminders so that users aren't overwhelmed by reminders