### PR TITLE
change feedback survey response logic

### DIFF
--- a/yal/askaquestion.py
+++ b/yal/askaquestion.py
@@ -44,7 +44,14 @@ class Application(BaseApplication):
     START_STATE = "state_aaq_start"
     TIMEOUT_RESPONSE_STATE = "state_handle_timeout_response"
     TRIGGER_KEYWORDS = {
-        "1", "yes ask again", "yes", "2", "no i m good", "nope", "3", "no go back to list"
+        "1",
+        "yes ask again",
+        "yes",
+        "2",
+        "no i m good",
+        "nope",
+        "3",
+        "no go back to list",
     }
 
     async def state_aaq_start(self, question=None, buttons=None):
@@ -528,9 +535,7 @@ class Application(BaseApplication):
             # Get it to display the message, instead of having this state try to
             # match it to a keyword
             self.inbound.session_event = Message.SESSION_EVENT.NEW
-            return await self.go_to_state(
-                "state_aaq_timeout_unrecognised_option"
-            )
+            return await self.go_to_state("state_aaq_timeout_unrecognised_option")
 
     async def state_aaq_timeout_unrecognised_option(self):
         choices = [

--- a/yal/askaquestion.py
+++ b/yal/askaquestion.py
@@ -43,7 +43,7 @@ def get_aaq_api():
 class Application(BaseApplication):
     START_STATE = "state_aaq_start"
     TIMEOUT_RESPONSE_STATE = "state_handle_timeout_response"
-    TRIGGER_KEYWORDS = {
+    AAQ_FEEDBACK_TRIGGER_KEYWORDS = {
         "1",
         "yes ask again",
         "yes",
@@ -526,7 +526,7 @@ class Application(BaseApplication):
         self.save_metadata("feedback_type", timeout_type_sent)
 
         keyword = clean_inbound(self.inbound.content)
-        if keyword in self.TRIGGER_KEYWORDS:
+        if keyword in self.AAQ_FEEDBACK_TRIGGER_KEYWORDS:
             if timeout_type_sent == "ask_a_question":
                 return await self.go_to_state("state_handle_list_timeout")
             if timeout_type_sent == "ask_a_question_2":

--- a/yal/askaquestion.py
+++ b/yal/askaquestion.py
@@ -88,6 +88,7 @@ class Application(BaseApplication):
         whatsapp_id = msisdn.lstrip(" + ")
 
         timeout_time = get_current_datetime() + timedelta(minutes=5)
+        self.save_metadata("feedback_timestamp", timeout_time.isoformat())
         data = {
             "feedback_timestamp": timeout_time.isoformat(),
             "feedback_type": "ask_a_question",
@@ -224,6 +225,7 @@ class Application(BaseApplication):
         whatsapp_id = msisdn.lstrip(" + ")
 
         timeout_time = get_current_datetime() + timedelta(minutes=5)
+        self.save_metadata("feedback_timestamp", timeout_time.isoformat())
         data = {
             "feedback_timestamp": timeout_time.isoformat(),
             "feedback_type": "ask_a_question_2",
@@ -502,9 +504,8 @@ class Application(BaseApplication):
         error, fields = await rapidpro.get_profile(whatsapp_id)
         if error:
             return await self.go_to_state("state_error")
-        data = {
-            "feedback_survey_sent": "",
-        }
+        self.save_metadata("feedback_timestamp", "")
+        data = {"feedback_survey_sent": "", "feedback_timestamp": ""}
         error = await rapidpro.update_profile(whatsapp_id, data)
         if error:
             return await self.go_to_state("state_error")

--- a/yal/askaquestion.py
+++ b/yal/askaquestion.py
@@ -92,7 +92,7 @@ class Application(BaseApplication):
         return EndState(
             self,
             self._("Coming soon..."),
-            next="state_aaq_start",
+            next=self.START_STATE,
         )
 
     async def state_set_aaq_timeout_1(self):

--- a/yal/askaquestion.py
+++ b/yal/askaquestion.py
@@ -92,7 +92,7 @@ class Application(BaseApplication):
         return EndState(
             self,
             self._("Coming soon..."),
-            next=self.START_STATE,
+            next="state_aaq_start",
         )
 
     async def state_set_aaq_timeout_1(self):
@@ -387,7 +387,7 @@ class Application(BaseApplication):
             question=question,
             choices=choices,
             next={
-                "aaq": self.START_STATE,
+                "aaq": "state_aaq_start",
                 "counsellor": PleaseCallMeApplication.START_STATE,
             },
             error=self._(get_generic_error()),
@@ -567,6 +567,6 @@ class Application(BaseApplication):
                 "feedback": feedback_state,
                 # hardcode to prevent circular import
                 "mainmenu": "state_pre_mainmenu",
-                "aaq": self.START_STATE,
+                "aaq": "state_aaq_start",
             },
         )

--- a/yal/content_feedback_survey.py
+++ b/yal/content_feedback_survey.py
@@ -14,7 +14,10 @@ class ContentFeedbackSurveyApplication(BaseApplication):
         msisdn = utils.normalise_phonenumber(self.inbound.from_addr)
         whatsapp_id = msisdn.lstrip("+")
         # Reset this, so that we only get the survey once after a push
-        await rapidpro.update_profile(whatsapp_id, {"feedback_survey_sent": ""})
+        self.save_metadata("feedback_timestamp", "")
+        await rapidpro.update_profile(
+            whatsapp_id, {"feedback_survey_sent": "", "feedback_timestamp": ""}
+        )
         return await self.go_to_state("state_process_content_feedback_trigger")
 
     async def state_process_content_feedback_trigger(self):

--- a/yal/content_feedback_survey.py
+++ b/yal/content_feedback_survey.py
@@ -11,7 +11,7 @@ from yal.pleasecallme import Application as PleaseCallMeApplication
 
 class ContentFeedbackSurveyApplication(BaseApplication):
     START_STATE = "state_content_feedback_survey_start"
-    TRIGGER_KEYWORDS = {"1", "yes thanks", "2", "not really"}
+    CONTENT_FEEDBACK_TRIGGER_KEYWORDS = {"1", "yes thanks", "2", "not really"}
 
     async def state_content_feedback_survey_start(self):
         msisdn = utils.normalise_phonenumber(self.inbound.from_addr)
@@ -22,7 +22,7 @@ class ContentFeedbackSurveyApplication(BaseApplication):
             whatsapp_id, {"feedback_survey_sent": "", "feedback_timestamp": ""}
         )
         keyword = utils.clean_inbound(self.inbound.content)
-        if keyword in self.TRIGGER_KEYWORDS:
+        if keyword in self.CONTENT_FEEDBACK_TRIGGER_KEYWORDS:
             return await self.go_to_state("state_process_content_feedback_trigger")
         else:
             # Get it to display the message, instead of having this state try to

--- a/yal/main.py
+++ b/yal/main.py
@@ -103,13 +103,14 @@ class Application(
         otherwise return None
         """
         feedback_timestamp = self.user.metadata.get("feedback_timestamp")
-        feedback_in_time = feedback_timestamp and datetime.fromisoformat(
-            feedback_timestamp
-        ) > get_current_datetime() - timedelta(minutes=1)
+        in_one_minute = get_current_datetime() + timedelta(minutes=1)
+        feedback_in_time = feedback_timestamp and (
+            datetime.fromisoformat(feedback_timestamp) < in_one_minute
+        )
         feedback_timestamp_2 = self.user.metadata.get("feedback_timestamp_2")
-        feedback_in_time_2 = feedback_timestamp_2 and datetime.fromisoformat(
-            feedback_timestamp_2
-        ) > get_current_datetime() - timedelta(minutes=1)
+        feedback_in_time_2 = feedback_timestamp_2 and (
+            datetime.fromisoformat(feedback_timestamp_2) < in_one_minute
+        )
         if feedback_in_time or feedback_in_time_2:
             msisdn = utils.normalise_phonenumber(self.inbound.from_addr)
             whatsapp_id = msisdn.lstrip("+")

--- a/yal/mainmenu.py
+++ b/yal/mainmenu.py
@@ -224,6 +224,7 @@ class Application(BaseApplication):
             whatsapp_id = msisdn.lstrip("+")
             timestamp = get_current_datetime() + timedelta(hours=2)
             # We ignore this error, as it just means they won't get the reminder
+            self.save_metadata("feedback_timestamp", timestamp.isoformat())
             await rapidpro.update_profile(
                 whatsapp_id,
                 {
@@ -310,6 +311,7 @@ class Application(BaseApplication):
         whatsapp_id = msisdn.lstrip("+")
         timestamp = utils.get_current_datetime() + timedelta(minutes=10)
         # We ignore this error, as it just means they won't get the reminder
+        self.save_metadata("feedback_timestamp", timestamp.isoformat())
         await rapidpro.update_profile(
             whatsapp_id,
             {

--- a/yal/servicefinder.py
+++ b/yal/servicefinder.py
@@ -333,6 +333,7 @@ class Application(BaseApplication):
     async def state_display_facilities(self):
         timestamp = utils.get_current_datetime() + self.SURVEY_DELAY
         whatsapp_id = utils.normalise_phonenumber(self.inbound.from_addr).lstrip("+")
+        self.save_metadata("feedback_timestamp", timestamp.isoformat())
         await rapidpro.update_profile(
             whatsapp_id=whatsapp_id,
             fields={

--- a/yal/servicefinder_feedback_survey.py
+++ b/yal/servicefinder_feedback_survey.py
@@ -20,8 +20,10 @@ class ServiceFinderFeedbackSurveyApplication(BaseApplication):
     SERVICEFINDER_TRIGGER_KEYWORDS = {
         "1",
         "yes thanks",
+        "yes i went",
         "2",
         "no not helpful",
+        "no i didn t go",
         "3",
         "i knew this before",
     }
@@ -44,7 +46,7 @@ class ServiceFinderFeedbackSurveyApplication(BaseApplication):
             # match it to a keyword
             self.inbound.session_event = Message.SESSION_EVENT.NEW
             self.save_metadata(
-                "feedback_return_state", "state_servicefinder_feedback_confirmation"
+                "feedback_return_state", "state_process_servicefinder_feedback_trigger"
             )
             return await self.go_to_state(
                 "state_servicefinder_feedback_unrecognised_option"

--- a/yal/servicefinder_feedback_survey.py
+++ b/yal/servicefinder_feedback_survey.py
@@ -17,7 +17,7 @@ class ServiceFinderFeedbackSurveyApplication(BaseApplication):
     CALLBACK_2_DELAY = timedelta(days=14)
     APPOINTMENT_TIPS_CONTENT_ID = 494
     APPOINTMENT_TIPS_MENU_LEVEL = 2
-    TRIGGER_KEYWORDS = {
+    SERVICEFINDER_TRIGGER_KEYWORDS = {
         "1",
         "yes thanks",
         "2",
@@ -35,7 +35,7 @@ class ServiceFinderFeedbackSurveyApplication(BaseApplication):
             whatsapp_id, {"feedback_survey_sent": "", "feedback_timestamp": ""}
         )
         keyword = utils.clean_inbound(self.inbound.content)
-        if keyword in self.TRIGGER_KEYWORDS:
+        if keyword in self.SERVICEFINDER_TRIGGER_KEYWORDS:
             return await self.go_to_state(
                 "state_process_servicefinder_feedback_trigger"
             )

--- a/yal/servicefinder_feedback_survey.py
+++ b/yal/servicefinder_feedback_survey.py
@@ -20,7 +20,10 @@ class ServiceFinderFeedbackSurveyApplication(BaseApplication):
         msisdn = utils.normalise_phonenumber(self.inbound.from_addr)
         whatsapp_id = msisdn.lstrip("+")
         # Reset this, so that we only get the survey once after a push
-        await rapidpro.update_profile(whatsapp_id, {"feedback_survey_sent": ""})
+        self.save_metadata("feedback_timestamp", "")
+        await rapidpro.update_profile(
+            whatsapp_id, {"feedback_survey_sent": "", "feedback_timestamp": ""}
+        )
         return await self.go_to_state("state_process_servicefinder_feedback_trigger")
 
     async def state_process_servicefinder_feedback_trigger(self):
@@ -135,6 +138,7 @@ class ServiceFinderFeedbackSurveyApplication(BaseApplication):
     async def state_save_servicefinder_callback_2(self):
         timestamp = utils.get_current_datetime() + self.CALLBACK_2_DELAY
         whatsapp_id = utils.normalise_phonenumber(self.inbound.from_addr).lstrip("+")
+        self.save_metadata("feedback_timestamp_2", timestamp.isoformat())
         await rapidpro.update_profile(
             whatsapp_id=whatsapp_id,
             fields={
@@ -180,7 +184,10 @@ class ServiceFinderFeedbackSurveyApplication(BaseApplication):
         # Repeat the question here for error and selection handling
         whatsapp_id = utils.normalise_phonenumber(self.inbound.from_addr).lstrip("+")
         # Reset this, so that we only get the survey once after a push
-        await rapidpro.update_profile(whatsapp_id, {"feedback_survey_sent_2": ""})
+        self.save_metadata("feedback_timestamp_2", "")
+        await rapidpro.update_profile(
+            whatsapp_id, {"feedback_survey_sent_2": "", "feedback_timestamp_2": ""}
+        )
         error, fields = await rapidpro.get_profile(whatsapp_id)
         if error:
             return await self.go_to_state("state_error")

--- a/yal/servicefinder_feedback_survey.py
+++ b/yal/servicefinder_feedback_survey.py
@@ -1,10 +1,12 @@
 from datetime import datetime, timedelta
 
 from vaccine.base_application import BaseApplication
+from vaccine.models import Message
 from vaccine.states import Choice, FreeText, WhatsAppButtonState
 from vaccine.utils import get_display_choices
 from yal import rapidpro, utils
 from yal.askaquestion import Application as AAQApplication
+from yal.mainmenu import Application as MainMenuApplication
 from yal.pleasecallme import Application as PCMApplication
 from yal.servicefinder import Application as SFApplication
 
@@ -15,6 +17,14 @@ class ServiceFinderFeedbackSurveyApplication(BaseApplication):
     CALLBACK_2_DELAY = timedelta(days=14)
     APPOINTMENT_TIPS_CONTENT_ID = 494
     APPOINTMENT_TIPS_MENU_LEVEL = 2
+    TRIGGER_KEYWORDS = {
+        "1",
+        "yes thanks",
+        "2",
+        "no not helpful",
+        "3",
+        "i knew this before",
+    }
 
     async def state_servicefinder_feedback_survey_start(self):
         msisdn = utils.normalise_phonenumber(self.inbound.from_addr)
@@ -24,7 +34,18 @@ class ServiceFinderFeedbackSurveyApplication(BaseApplication):
         await rapidpro.update_profile(
             whatsapp_id, {"feedback_survey_sent": "", "feedback_timestamp": ""}
         )
-        return await self.go_to_state("state_process_servicefinder_feedback_trigger")
+        keyword = utils.clean_inbound(self.inbound.content)
+        if keyword in self.TRIGGER_KEYWORDS:
+            return await self.go_to_state(
+                "state_process_servicefinder_feedback_trigger"
+            )
+        else:
+            # Get it to display the message, instead of having this state try to
+            # match it to a keyword
+            self.inbound.session_event = Message.SESSION_EVENT.NEW
+            return await self.go_to_state(
+                "state_servicefinder_feedback_unrecognised_option"
+            )
 
     async def state_process_servicefinder_feedback_trigger(self):
         # Mirror the message here, for response and error handling
@@ -53,6 +74,34 @@ class ServiceFinderFeedbackSurveyApplication(BaseApplication):
                 "yes": "state_servicefinder_positive_feedback",
                 "no": "state_servicefinder_negative_feedback",
                 "already_know": "state_servicefinder_already_know_feedback",
+            },
+        )
+
+    async def state_servicefinder_feedback_unrecognised_option(self):
+        choices = [
+            Choice("feedback", self._("Reply to last text")),
+            Choice("mainmenu", self._("Go to the Main Menu")),
+            Choice("aaq", self._("Ask a question")),
+        ]
+        question = "\n".join(
+            [
+                "*[persona_emoji] Hmm, looks like you've run out of time to respond to "
+                "that message.*",
+                "",
+                "*What would you like to do now? Here are some options.*",
+                "",
+                get_display_choices(choices),
+            ]
+        )
+        return WhatsAppButtonState(
+            self,
+            question=question,
+            choices=choices,
+            error=utils.get_generic_error(),
+            next={
+                "feedback": "state_process_servicefinder_feedback_trigger",
+                "mainmenu": MainMenuApplication.START_STATE,
+                "aaq": AAQApplication.START_STATE,
             },
         )
 

--- a/yal/tests/test_askaquestion.py
+++ b/yal/tests/test_askaquestion.py
@@ -9,7 +9,7 @@ from vaccine.models import Message
 from vaccine.testing import AppTester, MockServer, TState, run_sanic
 from yal import config
 from yal.main import Application
-from yal.utils import BACK_TO_MAIN, GET_HELP, get_current_datetime
+from yal.utils import BACK_TO_MAIN, GET_HELP
 
 
 @pytest.fixture
@@ -23,7 +23,7 @@ def get_rapidpro_contact(urn):
             "feedback_type": "ask_a_question"
             if ("27820001001" in urn)
             else "ask_a_question_2",
-            "feedback_sent": "TRUE"
+            "feedback_sent": "TRUE",
         },
     }
 
@@ -491,6 +491,7 @@ async def test_state_no_question_not_answered(
 
     tester.assert_message(message)
 
+
 @pytest.mark.asyncio
 async def test_timeout_invalid_keyword(tester: AppTester, rapidpro_mock: MockServer):
     """If the user responds with a keyword we don't recognise, show them the error"""
@@ -510,6 +511,7 @@ async def test_timeout_invalid_keyword_back_to_feedback(
 
     await tester.user_input("reply to last text")
     tester.assert_state("state_handle_list_timeout")
+
 
 @pytest.mark.asyncio
 async def test_state_display_content_question_back_to_list(

--- a/yal/tests/test_askaquestion.py
+++ b/yal/tests/test_askaquestion.py
@@ -161,7 +161,7 @@ async def test_aaq_start_coming_soon(tester: AppTester):
 
     await tester.user_input(session=Message.SESSION_EVENT.NEW)
 
-    tester.assert_state("state_start")
+    tester.assert_state("state_aaq_start")
     tester.assert_message("Coming soon...")
 
 

--- a/yal/tests/test_askaquestion.py
+++ b/yal/tests/test_askaquestion.py
@@ -161,7 +161,7 @@ async def test_aaq_start_coming_soon(tester: AppTester):
 
     await tester.user_input(session=Message.SESSION_EVENT.NEW)
 
-    tester.assert_state("state_aaq_start")
+    tester.assert_state("state_start")
     tester.assert_message("Coming soon...")
 
 

--- a/yal/tests/test_askaquestion.py
+++ b/yal/tests/test_askaquestion.py
@@ -383,8 +383,8 @@ async def test_state_get_content_feedback_question_answered(
 
     tester.assert_state("state_yes_question_answered")
 
-    assert len(rapidpro_mock.tstate.requests) == 2
-    request = rapidpro_mock.tstate.requests[1]
+    assert len(rapidpro_mock.tstate.requests) == 1
+    request = rapidpro_mock.tstate.requests[0]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {"feedback_type": ""},
     }
@@ -525,11 +525,12 @@ async def test_state_handle_timeout_handles_type_1_yes(
     tester.setup_state("state_handle_timeout_response")
     await tester.user_input("yes, ask again")
 
-    assert len(rapidpro_mock.tstate.requests) == 3
+    assert len(rapidpro_mock.tstate.requests) == 2
     request = rapidpro_mock.tstate.requests[-1]
     assert json.loads(request.body.decode("utf-8")) == {
-        "fields": {"feedback_survey_sent": ""},
+        "fields": {"feedback_survey_sent": "", "feedback_timestamp": ""},
     }
+    tester.assert_metadata("feedback_timestamp", "")
 
     tester.assert_state("state_aaq_start")
 
@@ -539,11 +540,12 @@ async def test_state_handle_timeout_handles_type_1_no(tester: AppTester, rapidpr
     tester.setup_state("state_handle_timeout_response")
     await tester.user_input("no, I'm good")
 
-    assert len(rapidpro_mock.tstate.requests) == 4
-    request = rapidpro_mock.tstate.requests[2]
+    assert len(rapidpro_mock.tstate.requests) == 3
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
-        "fields": {"feedback_survey_sent": ""},
+        "fields": {"feedback_survey_sent": "", "feedback_timestamp": ""},
     }
+    tester.assert_metadata("feedback_timestamp", "")
 
     tester.assert_state("state_mainmenu")
 
@@ -561,11 +563,12 @@ async def test_state_handle_timeout_handles_type_2_yes(
     tester.user.metadata["aaq_page"] = 0
     await tester.user_input(content="yes")
 
-    assert len(rapidpro_mock.tstate.requests) == 4
-    request = rapidpro_mock.tstate.requests[2]
+    assert len(rapidpro_mock.tstate.requests) == 3
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
-        "fields": {"feedback_survey_sent": ""},
+        "fields": {"feedback_survey_sent": "", "feedback_timestamp": ""},
     }
+    tester.assert_metadata("feedback_timestamp", "")
 
     tester.assert_state("state_yes_question_answered")
 
@@ -610,11 +613,12 @@ async def test_state_handle_timeout_handles_type_2_no(
     tester.user.metadata["aaq_page"] = 0
     await tester.user_input(content="nope...")
 
-    assert len(rapidpro_mock.tstate.requests) == 4
-    request = rapidpro_mock.tstate.requests[2]
+    assert len(rapidpro_mock.tstate.requests) == 3
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
-        "fields": {"feedback_survey_sent": ""},
+        "fields": {"feedback_survey_sent": "", "feedback_timestamp": ""},
     }
+    tester.assert_metadata("feedback_timestamp", "")
 
     tester.assert_state("state_no_question_not_answered")
 

--- a/yal/tests/test_change_preferences.py
+++ b/yal/tests/test_change_preferences.py
@@ -272,7 +272,7 @@ async def test_state_update_gender_confirm_not_correct(
     tester.assert_state("state_update_gender")
     tester.assert_num_messages(1)
 
-    assert [r.path for r in rapidpro_mock.tstate.requests] == ["/api/v2/contacts.json"]
+    assert [r.path for r in rapidpro_mock.tstate.requests] == []
 
 
 @pytest.mark.asyncio
@@ -331,7 +331,7 @@ async def test_state_update_age_confirm_not_correct(tester: AppTester, rapidpro_
     tester.assert_num_messages(1)
     tester.assert_state("state_update_age")
 
-    assert [r.path for r in rapidpro_mock.tstate.requests] == ["/api/v2/contacts.json"]
+    assert [r.path for r in rapidpro_mock.tstate.requests] == []
 
 
 @pytest.mark.asyncio
@@ -394,7 +394,7 @@ async def test_state_update_relationship_status_confirm_not_correct(
     tester.assert_num_messages(1)
     tester.assert_state("state_update_relationship_status")
 
-    assert [r.path for r in rapidpro_mock.tstate.requests] == ["/api/v2/contacts.json"]
+    assert [r.path for r in rapidpro_mock.tstate.requests] == []
 
 
 @pytest.mark.asyncio
@@ -409,7 +409,7 @@ async def test_state_update_relationship_status_submit(
 
     assert [r.path for r in rapidpro_mock.tstate.requests] == [
         "/api/v2/contacts.json",
-    ] * 2
+    ]
 
 
 @pytest.mark.asyncio
@@ -438,9 +438,7 @@ async def test_state_update_bot_name(tester: AppTester, rapidpro_mock):
         )
     )
 
-    assert [r.path for r in rapidpro_mock.tstate.requests] == [
-        "/api/v2/contacts.json"
-    ] * 2
+    assert [r.path for r in rapidpro_mock.tstate.requests] == ["/api/v2/contacts.json"]
 
 
 @pytest.mark.asyncio
@@ -637,8 +635,8 @@ async def test_state_update_location_submit(tester: AppTester, rapidpro_mock):
     tester.assert_num_messages(1)
     tester.assert_state("state_conclude_changes")
 
-    assert len(rapidpro_mock.tstate.requests) == 2
-    request = rapidpro_mock.tstate.requests[1]
+    assert len(rapidpro_mock.tstate.requests) == 1
+    request = rapidpro_mock.tstate.requests[0]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "latitude": 56.78,

--- a/yal/tests/test_content_feedback_survey.py
+++ b/yal/tests/test_content_feedback_survey.py
@@ -57,7 +57,11 @@ async def test_positive_feedback(tester: AppTester, rapidpro_mock: MockServer):
 
     assert rapidpro_mock.tstate
     [update_contact] = rapidpro_mock.tstate.requests
-    assert update_contact.json["fields"] == {"feedback_survey_sent": ""}
+    assert update_contact.json["fields"] == {
+        "feedback_survey_sent": "",
+        "feedback_timestamp": "",
+    }
+    tester.assert_metadata("feedback_timestamp", "")
 
 
 @pytest.mark.asyncio

--- a/yal/tests/test_content_feedback_survey.py
+++ b/yal/tests/test_content_feedback_survey.py
@@ -95,24 +95,10 @@ async def test_invalid_keyword(tester: AppTester, rapidpro_mock: MockServer):
     """If the user responds with a keyword we don't recognise, show them the error"""
     await tester.user_input("menu")
     tester.assert_state("state_content_feedback_unrecognised_option")
-    tester.assert_message(
-        "\n".join(
-            [
-                "*[persona_emoji] Hmm, looks like you've run out of time to respond to "
-                "that message.*",
-                "",
-                "*What would you like to do now? Here are some options.*",
-                "",
-                "1. Reply to last text",
-                "2. Go to the Main Menu",
-                "3. Ask a question",
-            ]
-        )
-    )
 
 
 @pytest.mark.asyncio
-async def test_invalid_keyword_back_to_main(
+async def test_invalid_keyword_back_to_feedback(
     tester: AppTester, rapidpro_mock: MockServer
 ):
     """If the user responds with a keyword we don't recognise, show them the error"""
@@ -121,20 +107,6 @@ async def test_invalid_keyword_back_to_main(
 
     await tester.user_input("reply to last text")
     tester.assert_state("state_process_content_feedback_trigger")
-    tester.assert_message(
-        "\n".join(
-            [
-                "[persona_emoji] Was the info you just read what you were looking for?",
-                "",
-                "1. Yes, thanks!",
-                "2. Not really",
-                "",
-                "-----",
-                BACK_TO_MAIN,
-                GET_HELP,
-            ]
-        )
-    )
 
 
 @pytest.mark.asyncio

--- a/yal/tests/test_content_feedback_survey.py
+++ b/yal/tests/test_content_feedback_survey.py
@@ -33,7 +33,7 @@ def tester():
 @pytest.mark.asyncio
 async def test_positive_feedback(tester: AppTester, rapidpro_mock: MockServer):
     """If the user responds positively to the push message, ask for any feedback"""
-    await tester.user_input("yes")
+    await tester.user_input("yes, thanks!")
     tester.assert_state("state_positive_feedback")
     tester.assert_message(
         "\n".join(
@@ -87,6 +87,53 @@ async def test_no_feedback(tester: AppTester):
                 GET_HELP,
             ]
         ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_invalid_keyword(tester: AppTester, rapidpro_mock: MockServer):
+    """If the user responds with a keyword we don't recognise, show them the error"""
+    await tester.user_input("menu")
+    tester.assert_state("state_content_feedback_unrecognised_option")
+    tester.assert_message(
+        "\n".join(
+            [
+                "*[persona_emoji] Hmm, looks like you've run out of time to respond to "
+                "that message.*",
+                "",
+                "*What would you like to do now? Here are some options.*",
+                "",
+                "1. Reply to last text",
+                "2. Go to the Main Menu",
+                "3. Ask a question",
+            ]
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_invalid_keyword_back_to_main(
+    tester: AppTester, rapidpro_mock: MockServer
+):
+    """If the user responds with a keyword we don't recognise, show them the error"""
+    await tester.user_input("menu")
+    tester.assert_state("state_content_feedback_unrecognised_option")
+
+    await tester.user_input("reply to last text")
+    tester.assert_state("state_process_content_feedback_trigger")
+    tester.assert_message(
+        "\n".join(
+            [
+                "[persona_emoji] Was the info you just read what you were looking for?",
+                "",
+                "1. Yes, thanks!",
+                "2. Not really",
+                "",
+                "-----",
+                BACK_TO_MAIN,
+                GET_HELP,
+            ]
+        )
     )
 
 

--- a/yal/tests/test_main.py
+++ b/yal/tests/test_main.py
@@ -20,7 +20,7 @@ from yal.servicefinder import Application as ServiceFinderApplication
 from yal.servicefinder_feedback_survey import ServiceFinderFeedbackSurveyApplication
 from yal.terms_and_conditions import Application as TermsApplication
 from yal.usertest_feedback import Application as FeedbackApplication
-from yal.utils import BACK_TO_MAIN, GET_HELP
+from yal.utils import BACK_TO_MAIN, GET_HELP, get_current_datetime
 
 
 def test_no_state_name_clashes():
@@ -353,6 +353,7 @@ async def test_aaq_timeout_response_to_handler(
     tester.user.metadata["faq_id"] = "1"
     tester.user.metadata["model_answers"] = MODEL_ANSWERS_PAGE_1
     tester.user.metadata["aaq_page"] = 0
+    tester.user.metadata["feedback_timestamp"] = get_current_datetime().isoformat()
     await tester.user_input("Nope...")
     tester.assert_state("state_no_question_not_answered")
     tester.assert_num_messages(1)
@@ -382,6 +383,7 @@ async def test_content_feedback_response(tester: AppTester, rapidpro_mock):
     If this is in response to a content feedback push message, then it should be handled
     by the content feedback state
     """
+    tester.user.metadata["feedback_timestamp"] = get_current_datetime().isoformat()
     tester.setup_user_address("27820001002")
     await tester.user_input("1")
     tester.assert_state("state_positive_feedback")
@@ -396,6 +398,7 @@ async def test_facebook_crossover_feedback_response(tester: AppTester, rapidpro_
     If this is in response to a fb feedback push message, then it should be handled
     by the fb feedback state
     """
+    tester.user.metadata["feedback_timestamp"] = get_current_datetime().isoformat()
     tester.setup_user_address("27820001003")
     await tester.user_input("yes, I did")
     tester.assert_state("state_saw_recent_facebook")
@@ -410,6 +413,7 @@ async def test_servicefinder_feedback_response(tester: AppTester, rapidpro_mock)
     If this is in response to a servicefinder feedback push message, then it should be
     handled by the servicefinder feedback application
     """
+    tester.user.metadata["feedback_timestamp"] = get_current_datetime().isoformat()
     tester.setup_user_address("27820001004")
     await tester.user_input("yes, thanks")
     tester.assert_state("state_servicefinder_positive_feedback")
@@ -424,6 +428,7 @@ async def test_servicefinder_feedback_2_response(tester: AppTester, rapidpro_moc
     If this is in response to the second servicefinder feedback push message, then it
     should be handled by the servicefinder feedback application
     """
+    tester.user.metadata["feedback_timestamp_2"] = get_current_datetime().isoformat()
     tester.setup_user_address("27820001005")
     await tester.user_input("yes, i went")
     tester.assert_state("state_went_to_service")

--- a/yal/tests/test_mainmenu.py
+++ b/yal/tests/test_mainmenu.py
@@ -909,7 +909,7 @@ async def test_state_mainmenu_contentrepo_children(
     assert params["data__session_id"][0] == "1"
     assert params["data__user_addr"][0] == "27820001001"
 
-    assert len(rapidpro_mock.tstate.requests) == 8
+    assert len(rapidpro_mock.tstate.requests) == 7
 
     update_request = rapidpro_mock.tstate.requests[-1]
     assert update_request.json["fields"] == {

--- a/yal/tests/test_mainmenu.py
+++ b/yal/tests/test_mainmenu.py
@@ -523,7 +523,7 @@ async def test_state_mainmenu_aaq(
     await tester.user_input("10")
 
     tester.assert_num_messages(1)
-    tester.assert_state("state_aaq_start")
+    tester.assert_state("state_start")
     tester.assert_message("Coming soon...")
 
     assert [r.path for r in contentrepo_api_mock.tstate.requests] == [
@@ -1198,7 +1198,7 @@ async def test_state_display_page_detail_aaq_feature(
 
     await tester.user_input("1")
 
-    tester.assert_state("state_aaq_start")
+    tester.assert_state("state_start")
 
 
 @pytest.mark.asyncio

--- a/yal/tests/test_mainmenu.py
+++ b/yal/tests/test_mainmenu.py
@@ -523,7 +523,7 @@ async def test_state_mainmenu_aaq(
     await tester.user_input("10")
 
     tester.assert_num_messages(1)
-    tester.assert_state("state_start")
+    tester.assert_state("state_aaq_start")
     tester.assert_message("Coming soon...")
 
     assert [r.path for r in contentrepo_api_mock.tstate.requests] == [
@@ -1198,7 +1198,7 @@ async def test_state_display_page_detail_aaq_feature(
 
     await tester.user_input("1")
 
-    tester.assert_state("state_start")
+    tester.assert_state("state_aaq_start")
 
 
 @pytest.mark.asyncio

--- a/yal/tests/test_mainmenu.py
+++ b/yal/tests/test_mainmenu.py
@@ -512,7 +512,7 @@ async def test_state_mainmenu_static(
         "/api/v2/pages",
     ]
 
-    assert len(rapidpro_mock.tstate.requests) == 3
+    assert len(rapidpro_mock.tstate.requests) == 2
 
 
 @pytest.mark.asyncio
@@ -622,8 +622,8 @@ async def test_state_mainmenu_contentrepo_help_content(
         "/api/v2/pages/1111",
     ]
 
-    assert len(rapidpro_mock.tstate.requests) == 5
-    request = rapidpro_mock.tstate.requests[2]
+    assert len(rapidpro_mock.tstate.requests) == 4
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "last_mainmenu_time": "",

--- a/yal/tests/test_onboarding.py
+++ b/yal/tests/test_onboarding.py
@@ -266,8 +266,8 @@ async def test_state_gender_from_list(
 
     tester.assert_answer("state_gender", "male")
 
-    assert len(rapidpro_mock.tstate.requests) == 4
-    request = rapidpro_mock.tstate.requests[1]
+    assert len(rapidpro_mock.tstate.requests) == 3
+    request = rapidpro_mock.tstate.requests[0]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "last_onboarding_time": "2022-06-19T17:30:00",

--- a/yal/tests/test_optout.py
+++ b/yal/tests/test_optout.py
@@ -178,13 +178,11 @@ async def test_state_optout_stop_notifications(
     await tester.user_input("1")
     tester.assert_state("state_optout_survey")
 
-    assert len(rapidpro_mock.tstate.requests) == 2
+    assert len(rapidpro_mock.tstate.requests) == 1
 
-    assert [r.path for r in rapidpro_mock.tstate.requests] == [
-        "/api/v2/contacts.json"
-    ] * 2
+    assert [r.path for r in rapidpro_mock.tstate.requests] == ["/api/v2/contacts.json"]
 
-    post_request = rapidpro_mock.tstate.requests[1]
+    post_request = rapidpro_mock.tstate.requests[0]
     assert json.loads(post_request.body.decode("utf-8")) == {
         "fields": {
             "onboarding_completed": "",
@@ -209,12 +207,12 @@ async def test_state_optout_delete_saved(tester: AppTester, rapidpro_mock):
 
     # Two API calls:
     # Get profile to get old details, update profile
-    assert len(rapidpro_mock.tstate.requests) == 3
+    assert len(rapidpro_mock.tstate.requests) == 2
     assert [r.path for r in rapidpro_mock.tstate.requests] == [
         "/api/v2/contacts.json"
-    ] * 3
+    ] * 2
 
-    post_request = rapidpro_mock.tstate.requests[2]
+    post_request = rapidpro_mock.tstate.requests[1]
     assert json.loads(post_request.body.decode("utf-8")) == {
         "fields": {
             "dob_year": "",

--- a/yal/tests/test_pleasecallme.py
+++ b/yal/tests/test_pleasecallme.py
@@ -325,8 +325,8 @@ async def test_callback_check_scheduled_if_out_of_hours(
         "SourceSystem": "Bwise by Young Africa live WhatsApp bot",
     }
 
-    assert len(rapidpro_mock.tstate.requests) == 2
-    request = rapidpro_mock.tstate.requests[1]
+    assert len(rapidpro_mock.tstate.requests) == 1
+    request = rapidpro_mock.tstate.requests[0]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {"callback_check_time": "2022-06-20T11:00:00"},
     }
@@ -348,8 +348,8 @@ async def test_state_in_hours(
         "SourceSystem": "Bwise by Young Africa live WhatsApp bot",
     }
 
-    assert len(rapidpro_mock.tstate.requests) == 2
-    request = rapidpro_mock.tstate.requests[1]
+    assert len(rapidpro_mock.tstate.requests) == 1
+    request = rapidpro_mock.tstate.requests[0]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {"callback_check_time": "2022-06-19T19:30:00"},
     }
@@ -457,8 +457,8 @@ async def test_state_ask_to_save_emergency_number(
         "SourceSystem": "Bwise by Young Africa live WhatsApp bot",
     }
 
-    assert len(rapidpro_mock.tstate.requests) == 2
-    request = rapidpro_mock.tstate.requests[1]
+    assert len(rapidpro_mock.tstate.requests) == 1
+    request = rapidpro_mock.tstate.requests[0]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {"callback_check_time": "2022-06-19T19:30:00"},
     }
@@ -481,12 +481,12 @@ async def test_state_save_emergency_contact(
         "SourceSystem": "Bwise by Young Africa live WhatsApp bot",
     }
 
-    assert len(rapidpro_mock.tstate.requests) == 3
-    request = rapidpro_mock.tstate.requests[1]
+    assert len(rapidpro_mock.tstate.requests) == 2
+    request = rapidpro_mock.tstate.requests[0]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {"emergency_contact": "+27831231234"},
     }
-    request = rapidpro_mock.tstate.requests[2]
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {"callback_check_time": "2022-06-19T19:30:00"},
     }

--- a/yal/tests/test_servicefinder_feedback_survey.py
+++ b/yal/tests/test_servicefinder_feedback_survey.py
@@ -59,7 +59,11 @@ async def test_state_process_servicefinder_feedback_trigger(
     tester.assert_state("state_process_servicefinder_feedback_trigger")
     assert rapidpro_mock.tstate is not None
     [request] = rapidpro_mock.tstate.requests
-    assert request.json["fields"] == {"feedback_survey_sent": ""}
+    assert request.json["fields"] == {
+        "feedback_survey_sent": "",
+        "feedback_timestamp": "",
+    }
+    tester.assert_metadata("feedback_timestamp", "")
 
 
 @pytest.mark.asyncio

--- a/yal/tests/test_servicefinder_feedback_survey.py
+++ b/yal/tests/test_servicefinder_feedback_survey.py
@@ -55,7 +55,7 @@ async def rapidpro_mock():
 async def test_state_process_servicefinder_feedback_trigger(
     tester: AppTester, rapidpro_mock: MockServer
 ):
-    await tester.user_input(session=Message.SESSION_EVENT.NEW)
+    await tester.user_input("yes, thanks", session=Message.SESSION_EVENT.NEW)
     tester.assert_state("state_process_servicefinder_feedback_trigger")
     assert rapidpro_mock.tstate is not None
     [request] = rapidpro_mock.tstate.requests
@@ -64,6 +64,25 @@ async def test_state_process_servicefinder_feedback_trigger(
         "feedback_timestamp": "",
     }
     tester.assert_metadata("feedback_timestamp", "")
+
+
+@pytest.mark.asyncio
+async def test_invalid_keyword(tester: AppTester, rapidpro_mock: MockServer):
+    """If the user responds with a keyword we don't recognise, show them the error"""
+    await tester.user_input("menu")
+    tester.assert_state("state_servicefinder_feedback_unrecognised_option")
+
+
+@pytest.mark.asyncio
+async def test_invalid_keyword_back_to_feedback(
+    tester: AppTester, rapidpro_mock: MockServer
+):
+    """If the user responds with a keyword we don't recognise, show them the error"""
+    await tester.user_input("menu")
+    tester.assert_state("state_servicefinder_feedback_unrecognised_option")
+
+    await tester.user_input("reply to last text")
+    tester.assert_state("state_process_servicefinder_feedback_trigger")
 
 
 @pytest.mark.asyncio

--- a/yal/tests/test_usertest_feedback.py
+++ b/yal/tests/test_usertest_feedback.py
@@ -319,8 +319,8 @@ async def test_state_submit_completed_feedback(tester: AppTester, rapidpro_mock)
         )
     )
 
-    assert len(rapidpro_mock.tstate.requests) == 2
-    request = rapidpro_mock.tstate.requests[1]
+    assert len(rapidpro_mock.tstate.requests) == 1
+    request = rapidpro_mock.tstate.requests[0]
     assert json.loads(request.body.decode("utf-8")) == {
         "flow": "usertesting-flow-uid",
         "urns": ["whatsapp:27820001001"],

--- a/yal/tests/test_wa_fb_crossover_feedback.py
+++ b/yal/tests/test_wa_fb_crossover_feedback.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 import pytest
 from sanic import Sanic, response
 
-from vaccine.testing import AppTester, TState, run_sanic
+from vaccine.testing import AppTester, MockServer, TState, run_sanic
 from yal import config
 from yal.utils import BACK_TO_MAIN, GET_HELP
 from yal.wa_fb_crossover_feedback import Application
@@ -53,6 +53,25 @@ async def rapidpro_mock():
         server.tstate = tstate
         yield server
         config.RAPIDPRO_URL = url
+
+
+@pytest.mark.asyncio
+async def test_invalid_keyword(tester: AppTester, rapidpro_mock: MockServer):
+    """If the user responds with a keyword we don't recognise, show them the error"""
+    await tester.user_input("menu")
+    tester.assert_state("state_wa_fb_crossover_feedback_unrecognised_option")
+
+
+@pytest.mark.asyncio
+async def test_invalid_keyword_back_to_feedback(
+    tester: AppTester, rapidpro_mock: MockServer
+):
+    """If the user responds with a keyword we don't recognise, show them the error"""
+    await tester.user_input("menu")
+    tester.assert_state("state_wa_fb_crossover_feedback_unrecognised_option")
+
+    await tester.user_input("reply to last text")
+    tester.assert_state("state_wa_fb_crossover_feedback")
 
 
 @pytest.mark.asyncio

--- a/yal/wa_fb_crossover_feedback.py
+++ b/yal/wa_fb_crossover_feedback.py
@@ -24,7 +24,10 @@ class Application(BaseApplication):
         msisdn = utils.normalise_phonenumber(self.inbound.from_addr)
         whatsapp_id = msisdn.lstrip("+")
         # Reset this, so that we only get the survey once after a push
-        await rapidpro.update_profile(whatsapp_id, {"feedback_survey_sent": ""})
+        self.save_metadata("feedback_timestamp", "")
+        await rapidpro.update_profile(
+            whatsapp_id, {"feedback_survey_sent": "", "feedback_timestamp": ""}
+        )
         return await self.go_to_state("state_wa_fb_crossover_feedback")
 
     async def state_wa_fb_crossover_feedback(self):

--- a/yal/wa_fb_crossover_feedback.py
+++ b/yal/wa_fb_crossover_feedback.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 class Application(BaseApplication):
     START_STATE = "state_crossover_feedback_survey_start"
-    TRIGGER_KEYWORDS = {"1", "yes i did", "2", "no i didn t"}
+    WA_FB_CROSSOVER_TRIGGER_KEYWORDS = {"1", "yes i did", "2", "no i didn t"}
 
     async def state_crossover_feedback_survey_start(self):
         msisdn = utils.normalise_phonenumber(self.inbound.from_addr)
@@ -32,7 +32,7 @@ class Application(BaseApplication):
             whatsapp_id, {"feedback_survey_sent": "", "feedback_timestamp": ""}
         )
         keyword = utils.clean_inbound(self.inbound.content)
-        if keyword in self.TRIGGER_KEYWORDS:
+        if keyword in self.WA_FB_CROSSOVER_TRIGGER_KEYWORDS:
             return await self.go_to_state("state_wa_fb_crossover_feedback")
         else:
             # Get it to display the message, instead of having this state try to


### PR DESCRIPTION
- Only check rapidpro contact if feedback_timestamp is within a minute of current time
- Ensure that the feedback state gets called for both new and existing sessions
