### PR TITLE
Add reset feedback timestamp keyword

### DIFF
--- a/yal/main.py
+++ b/yal/main.py
@@ -36,6 +36,7 @@ FEEDBACK_FIELDS = {
     "feedback_timestamp",
     "feedback_timestamp_2",
 }
+QA_RESET_FEEDBACK_TIMESTAMP_KEYWORDS = {"resetfeedbacktimestampobzvmp"}
 
 
 class Application(
@@ -90,6 +91,10 @@ class Application(
                 self.user.session_id = None
                 self.state_name = OnboardingApplication.REMINDER_STATE
 
+        if keyword in QA_RESET_FEEDBACK_TIMESTAMP_KEYWORDS:
+            self.user.session_id = None
+            self.state_name = "state_qa_reset_feedback_timestamp_keywords"
+
         self.inbound = message
         feedback_state = await self.get_feedback_state()
         if feedback_state:
@@ -99,6 +104,14 @@ class Application(
             self.state_name = feedback_state
 
         return await super().process_message(message)
+
+    async def state_qa_reset_feedback_timestamp_keywords(self):
+        self.save_metadata("feedback_timestamp", get_current_datetime().isoformat())
+        return EndState(
+            self,
+            text="QA: Success! You can now modify the timestamp in RapidPro to trigger "
+            "the message early",
+        )
 
     async def get_feedback_state(self):
         """

--- a/yal/tests/test_main.py
+++ b/yal/tests/test_main.py
@@ -437,3 +437,18 @@ async def test_servicefinder_feedback_2_response(tester: AppTester, rapidpro_moc
     tester.assert_num_messages(1)
 
     assert len(rapidpro_mock.tstate.requests) == 3
+
+
+@pytest.mark.asyncio
+async def test_state_qa_reset_feedback_timestamp_keywords(
+    tester: AppTester, rapidpro_mock
+):
+    old_timestamp = get_current_datetime().isoformat()
+    tester.user.metadata["feedback_timestamp"] = old_timestamp
+    await tester.user_input("resetfeedbacktimestampobzvmp")
+    tester.assert_state(None)
+    tester.assert_message(
+        "QA: Success! You can now modify the timestamp in RapidPro to trigger "
+        "the message early"
+    )
+    assert tester.user.metadata["feedback_timestamp"] != old_timestamp


### PR DESCRIPTION
This is a keyword in order to speed up QA. It resets the feedback timestamp to the current time, so that the feedback flows can be tested immediately, instead of waiting for the delay time
