### PR TITLE
main menu do not increment menu level when retrieving the next whatsapp message, only when going to a child page in content repo

### DIFF
--- a/yal/mainmenu.py
+++ b/yal/mainmenu.py
@@ -336,7 +336,8 @@ class Application(BaseApplication):
             "feature_redirects", page_details.get("feature_redirects", [])
         )
 
-        # do not increment menu level if traveling horizontally
+        # do not increment menu level when retrieving the next whatsapp message,
+        # only when going to a child page in content repo
         if message_id > 1:
             menu_level = metadata["current_menu_level"]
         else:

--- a/yal/mainmenu.py
+++ b/yal/mainmenu.py
@@ -336,7 +336,11 @@ class Application(BaseApplication):
             "feature_redirects", page_details.get("feature_redirects", [])
         )
 
-        menu_level = metadata["current_menu_level"] + 1
+        # do not increment menu level if traveling horizontally
+        if message_id > 1:
+            menu_level = metadata["current_menu_level"]
+        else:
+            menu_level = metadata["current_menu_level"] + 1
         self.save_metadata("current_menu_level", menu_level)
 
         if page_details["has_children"]:

--- a/yal/tests/test_mainmenu.py
+++ b/yal/tests/test_mainmenu.py
@@ -618,10 +618,12 @@ async def test_state_mainmenu_contentrepo_help_content(
         ]
     )
 
+    assert tester.user.metadata["current_menu_level"] == 1
     tester.assert_num_messages(1)
     tester.assert_message(question)
 
     await tester.user_input("1")
+    assert tester.user.metadata["current_menu_level"] == 1
 
     assert [r.path for r in contentrepo_api_mock.tstate.requests] == [
         "/api/v2/pages",

--- a/yal/tests/test_mainmenu.py
+++ b/yal/tests/test_mainmenu.py
@@ -212,21 +212,6 @@ async def contentrepo_api_mock():
             ),
         )
 
-    @app.route("/api/v2/pages/1111/?message=2", methods=["GET"])
-    def get_page_detail_1111_2(request):
-        tstate.requests.append(request)
-        return response.json(
-            build_message_detail(
-                111,
-                "Main Menu 1 💊",
-                "Message test content 2",
-                total_messages=2,
-                message=2,
-                next_message=None,
-                previous_message=1,
-            ),
-        )
-
     @app.route("/api/v2/pages/1112", methods=["GET"])
     def get_page_detail_1112(request):
         tstate.requests.append(request)
@@ -646,9 +631,13 @@ async def test_state_mainmenu_contentrepo_help_content(
         "/suggestedcontent/",
         "/api/v2/pages",
         "/api/v2/pages/1111",
+        "/api/v2/pages/1111",
     ]
 
-    assert len(rapidpro_mock.tstate.requests) == 4
+    request = contentrepo_api_mock.tstate.requests[-1]
+    assert request.args["message"] == ["2"]
+
+    assert len(rapidpro_mock.tstate.requests) == 7
     request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {

--- a/yal/tests/test_mainmenu.py
+++ b/yal/tests/test_mainmenu.py
@@ -42,15 +42,18 @@ def build_message_detail(
     total_messages=1,
     quick_replies=[],
     related_pages=[],
+    message=1,
+    next_message=None,
+    previous_message=None,
 ):
     return {
         "id": id,
         "title": title,
         "subtitle": None,
         "body": {
-            "message": 1,
-            "next_message": None,
-            "previous_message": None,
+            "message": message,
+            "next_message": next_message,
+            "previous_message": previous_message,
             "total_messages": total_messages,
             "text": {
                 "type": "Whatsapp_Message",
@@ -203,7 +206,25 @@ async def contentrepo_api_mock():
                 111,
                 "Main Menu 1 💊",
                 "Message test content 1",
-            )
+                total_messages=2,
+                message=1,
+                next_message=2,
+            ),
+        )
+
+    @app.route("/api/v2/pages/1111/?message=2", methods=["GET"])
+    def get_page_detail_1111_2(request):
+        tstate.requests.append(request)
+        return response.json(
+            build_message_detail(
+                111,
+                "Main Menu 1 💊",
+                "Message test content 2",
+                total_messages=2,
+                message=2,
+                next_message=None,
+                previous_message=1,
+            ),
         )
 
     @app.route("/api/v2/pages/1112", methods=["GET"])
@@ -603,6 +624,8 @@ async def test_state_mainmenu_contentrepo_help_content(
             "",
             "Message test content 1",
             "",
+            "1. Next",
+            "",
             "-----",
             "*Or reply:*",
             BACK_TO_MAIN,
@@ -612,6 +635,8 @@ async def test_state_mainmenu_contentrepo_help_content(
 
     tester.assert_num_messages(1)
     tester.assert_message(question)
+
+    await tester.user_input("1")
 
     assert [r.path for r in contentrepo_api_mock.tstate.requests] == [
         "/api/v2/pages",


### PR DESCRIPTION
Currently when we step through messages from contentrepo on the same page, the menu level is incremented and we get a "something went wrong" when we try go back. 