### PR TITLE
Get RapidPro contact on inbound message

### DIFF
--- a/yal/askaquestion.py
+++ b/yal/askaquestion.py
@@ -106,7 +106,7 @@ class Application(BaseApplication):
             "feedback_type": "ask_a_question",
         }
 
-        error = await rapidpro.update_profile(whatsapp_id, data)
+        error = await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)
         if error:
             return await self.go_to_state("state_error")
 
@@ -267,7 +267,7 @@ class Application(BaseApplication):
             "feedback_type": "ask_a_question_2",
         }
 
-        error = await rapidpro.update_profile(whatsapp_id, data)
+        error = await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)
         if error:
             return await self.go_to_state("state_error")
 
@@ -323,7 +323,7 @@ class Application(BaseApplication):
             "feedback_type": "",
         }
 
-        error = await rapidpro.update_profile(whatsapp_id, data)
+        error = await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)
         if error:
             return await self.go_to_state("state_error")
 
@@ -537,17 +537,12 @@ class Application(BaseApplication):
         msisdn = normalise_phonenumber(self.inbound.from_addr)
         whatsapp_id = msisdn.lstrip(" + ")
 
-        error, fields = await rapidpro.get_profile(whatsapp_id)
-        if error:
-            return await self.go_to_state("state_error")
-        self.save_metadata("feedback_timestamp", "")
         data = {"feedback_survey_sent": "", "feedback_timestamp": ""}
-        error = await rapidpro.update_profile(whatsapp_id, data)
+        error = await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)
         if error:
             return await self.go_to_state("state_error")
 
-        timeout_type_sent = fields.get("feedback_type")
-        self.save_metadata("feedback_type", timeout_type_sent)
+        timeout_type_sent = self.user.metadata.get("feedback_type")
 
         keyword = clean_inbound(self.inbound.content)
         if keyword in self.AAQ_FEEDBACK_TRIGGER_KEYWORDS:

--- a/yal/content_feedback_survey.py
+++ b/yal/content_feedback_survey.py
@@ -17,9 +17,10 @@ class ContentFeedbackSurveyApplication(BaseApplication):
         msisdn = utils.normalise_phonenumber(self.inbound.from_addr)
         whatsapp_id = msisdn.lstrip("+")
         # Reset this, so that we only get the survey once after a push
-        self.save_metadata("feedback_timestamp", "")
         await rapidpro.update_profile(
-            whatsapp_id, {"feedback_survey_sent": "", "feedback_timestamp": ""}
+            whatsapp_id,
+            {"feedback_survey_sent": "", "feedback_timestamp": ""},
+            self.user.metadata,
         )
         keyword = utils.clean_inbound(self.inbound.content)
         if keyword in self.CONTENT_FEEDBACK_TRIGGER_KEYWORDS:

--- a/yal/docs/contact_fields.md
+++ b/yal/docs/contact_fields.md
@@ -1,0 +1,11 @@
+Introduction
+------------
+
+For any contact fields that we need to store permanently, we store these in RapidPro. There is a `rapidpro.py` module which has helper methods for updating contact fields in RapidPro.
+
+On every inbound message, we fetch these contact fields, and store them in `self.user.metadata`. So you should not use the `get_profile` method, rather used the fields cached in `self.user.metadata`. The `update_profile` method in `rapidpro.py` also updates the field in `self.user.metadata` to ensure that they stay in sync.
+
+
+Fields
+------
+TODO: Create a list of field names, and what their purpose is

--- a/yal/main.py
+++ b/yal/main.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime, timedelta
 
 from vaccine.models import Message
 from vaccine.states import EndState
@@ -47,10 +46,6 @@ ONBOARDING_REMINDER_KEYWORDS = {
 }
 CALLBACK_CHECK_KEYWORDS = {"callback"}
 FEEDBACK_KEYWORDS = {"feedback"}
-FEEDBACK_FIELDS = {
-    "feedback_timestamp",
-    "feedback_timestamp_2",
-}
 QA_RESET_FEEDBACK_TIMESTAMP_KEYWORDS = {"resetfeedbacktimestampobzvmp"}
 SEGMENT_SURVEY_ACCEPT = {"hell yeah"}
 SEGMENT_SURVEY_DECLINE = {"no rather not"}
@@ -75,8 +70,16 @@ class Application(
     START_STATE = "state_start"
 
     async def process_message(self, message):
+        msisdn = utils.normalise_phonenumber(message.from_addr)
+        whatsapp_id = msisdn.lstrip(" + ")
+        error, fields = await rapidpro.get_profile(whatsapp_id)
+        if error:
+            return await self.go_to_state("state_error")
+        for key, value in fields.items():
+            self.save_metadata(key, value)
+
         keyword = utils.clean_inbound(message.content)
-        # Restart keywords
+        # Restart keywords that interrupt the current flow
         if keyword in GREETING_KEYWORDS or keyword in TRACKING_KEYWORDS:
             self.user.session_id = None
             self.state_name = self.START_STATE
@@ -97,25 +100,13 @@ class Application(
             self.user.session_id = None
             self.state_name = PleaseCallMeApplication.CALLBACK_RESPONSE_STATE
 
-        if keyword in ONBOARDING_REMINDER_KEYWORDS:
-            msisdn = utils.normalise_phonenumber(message.from_addr)
-            whatsapp_id = msisdn.lstrip(" + ")
-            error, fields = await rapidpro.get_profile(whatsapp_id)
-            if error:
-                return await self.go_to_state("state_error")
-
-            onboarding_reminder_sent = fields.get("onboarding_reminder_sent")
-            if onboarding_reminder_sent:
-                self.user.session_id = None
-                self.state_name = OnboardingApplication.REMINDER_STATE
+        if keyword in QA_RESET_FEEDBACK_TIMESTAMP_KEYWORDS:
+            self.user.session_id = None
+            self.state_name = "state_qa_reset_feedback_timestamp_keywords"
 
         if keyword in SEGMENT_SURVEY_ACCEPT or keyword in SEGMENT_SURVEY_DECLINE:
-            msisdn = utils.normalise_phonenumber(message.from_addr)
-            whatsapp_id = msisdn.lstrip(" + ")
-            error, fields = await rapidpro.get_profile(whatsapp_id)
-
-            segment_survey_complete = str(
-                fields.get("segment_survey_complete", "False")
+            segment_survey_complete = self.user.metadata.get(
+                "segment_survey_complete", "false"
             ).lower()
             if segment_survey_complete == "pending":
                 self.user.session_id = None
@@ -127,16 +118,17 @@ class Application(
                 self.user.session_id = None
                 self.state_name = SegmentSurveyApplication.COMPLETED_STATE
 
-        if keyword in QA_RESET_FEEDBACK_TIMESTAMP_KEYWORDS:
-            self.user.session_id = None
-            self.state_name = "state_qa_reset_feedback_timestamp_keywords"
+        if keyword in ONBOARDING_REMINDER_KEYWORDS:
+            if self.user.metadata.get("onboarding_reminder_sent"):
+                self.user.session_id = None
+                self.state_name = OnboardingApplication.REMINDER_STATE
 
-        self.inbound = message
+        # Fields that RapidPro sets after a push message
         feedback_state = await self.get_feedback_state()
         if feedback_state:
             if not self.user.session_id:
                 self.user.session_id = random_id()
-            self.inbound.session_event = Message.SESSION_EVENT.RESUME
+            message.session_event = Message.SESSION_EVENT.RESUME
             self.state_name = feedback_state
 
         return await super().process_message(message)
@@ -154,68 +146,27 @@ class Application(
         If the user needs to be in a feedback state, send return that state name,
         otherwise return None
         """
-        feedback_timestamp = self.user.metadata.get("feedback_timestamp")
-        in_one_minute = get_current_datetime() + timedelta(minutes=1)
-        feedback_in_time = feedback_timestamp and (
-            datetime.fromisoformat(feedback_timestamp) < in_one_minute
-        )
-        feedback_timestamp_2 = self.user.metadata.get("feedback_timestamp_2")
-        feedback_in_time_2 = feedback_timestamp_2 and (
-            datetime.fromisoformat(feedback_timestamp_2) < in_one_minute
-        )
-        if feedback_in_time or feedback_in_time_2:
-            msisdn = utils.normalise_phonenumber(self.inbound.from_addr)
-            whatsapp_id = msisdn.lstrip("+")
-            error, fields = await rapidpro.get_profile(whatsapp_id)
-            if error:
-                return "state_error"
-            feedback_survey_sent = fields.get("feedback_survey_sent")
-            feedback_type = fields.get("feedback_type")
-            if feedback_survey_sent and feedback_type == "content":
-                return ContentFeedbackSurveyApplication.START_STATE
-            if feedback_survey_sent and feedback_type == "facebook_banner":
-                return WaFbCrossoverFeedbackApplication.START_STATE
-            if feedback_survey_sent and feedback_type == "servicefinder":
-                return ServiceFinderFeedbackSurveyApplication.START_STATE
-            if feedback_survey_sent and (
-                feedback_type == "ask_a_question" or feedback_type == "ask_a_question_2"
-            ):
-                return AaqApplication.TIMEOUT_RESPONSE_STATE
+        feedback_survey_sent = self.user.metadata.get("feedback_survey_sent")
+        feedback_type = self.user.metadata.get("feedback_type")
+        if feedback_survey_sent and feedback_type == "content":
+            return ContentFeedbackSurveyApplication.START_STATE
+        if feedback_survey_sent and feedback_type == "facebook_banner":
+            return WaFbCrossoverFeedbackApplication.START_STATE
+        if feedback_survey_sent and feedback_type == "servicefinder":
+            return ServiceFinderFeedbackSurveyApplication.START_STATE
+        if feedback_survey_sent and (
+            feedback_type == "ask_a_question" or feedback_type == "ask_a_question_2"
+        ):
+            return AaqApplication.TIMEOUT_RESPONSE_STATE
 
-            feedback_survey_sent_2 = fields.get("feedback_survey_sent_2")
-            feedback_type_2 = fields.get("feedback_type_2")
-            if feedback_survey_sent_2 and feedback_type_2 == "servicefinder":
-                return ServiceFinderFeedbackSurveyApplication.CALLBACK_2_STATE
+        feedback_survey_sent_2 = self.user.metadata.get("feedback_survey_sent_2")
+        feedback_type_2 = self.user.metadata.get("feedback_type_2")
+        if feedback_survey_sent_2 and feedback_type_2 == "servicefinder":
+            return ServiceFinderFeedbackSurveyApplication.CALLBACK_2_STATE
 
     async def state_start(self):
-        msisdn = utils.normalise_phonenumber(self.inbound.from_addr)
-        whatsapp_id = msisdn.lstrip(" + ")
-
-        error, fields = await rapidpro.get_profile(whatsapp_id)
-        if error:
-            return await self.go_to_state("state_error")
-
-        terms_accepted = fields.get("terms_accepted")
-        onboarding_completed = fields.get("onboarding_completed")
-
-        # Cache some profile info
-        for field in ("latitude", "longitude", "location_description"):
-            if fields.get(field):
-                self.save_metadata(field, fields[field])
-        for field in utils.PERSONA_FIELDS:
-            if fields.get(field):
-                self.save_metadata(field, fields[field])
-        for field in FEEDBACK_FIELDS:
-            if fields.get(field):
-                self.save_metadata(field, fields[field])
-
-        feedback_state = await self.get_feedback_state()
-        if feedback_state:
-            # Treat this like a session resume
-            if not self.user.session_id:
-                self.user.session_id = random_id()
-            self.inbound.session_event = Message.SESSION_EVENT.RESUME
-            return await self.go_to_state(feedback_state)
+        terms_accepted = self.user.metadata.get("terms_accepted")
+        onboarding_completed = self.user.metadata.get("onboarding_completed")
 
         inbound = utils.clean_inbound(self.inbound.content)
 

--- a/yal/mainmenu.py
+++ b/yal/mainmenu.py
@@ -25,7 +25,7 @@ class Application(BaseApplication):
         if suggested_text:
             data["suggested_text"] = suggested_text
 
-        return await rapidpro.update_profile(whatsapp_id, data)
+        return await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)
 
     async def reset_suggested_content_details(self):
         msisdn = utils.normalise_phonenumber(self.inbound.from_addr)
@@ -34,7 +34,7 @@ class Application(BaseApplication):
             "last_mainmenu_time": "",
             "suggested_text": "",
         }
-        return await rapidpro.update_profile(whatsapp_id, data)
+        return await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)
 
     async def get_suggested_choices(self, parent_topic_links={}):
         if self.user.metadata["suggested_content"] == {}:
@@ -217,13 +217,13 @@ class Application(BaseApplication):
             whatsapp_id = msisdn.lstrip("+")
             timestamp = get_current_datetime() + timedelta(hours=2)
             # We ignore this error, as it just means they won't get the reminder
-            self.save_metadata("feedback_timestamp", timestamp.isoformat())
             await rapidpro.update_profile(
                 whatsapp_id,
                 {
                     "feedback_timestamp": timestamp.isoformat(),
                     "feedback_type": "facebook_banner",
                 },
+                self.user.metadata,
             )
         return CustomChoiceState(
             self,
@@ -240,13 +240,7 @@ class Application(BaseApplication):
         )
 
     async def state_check_relationship_status_set(self):
-        msisdn = utils.normalise_phonenumber(self.inbound.from_addr)
-        whatsapp_id = msisdn.lstrip("+")
-        error, fields = await rapidpro.get_profile(whatsapp_id)
-        if error:
-            return await self.go_to_state("state_error")
-
-        rel_status = fields.get("relationship_status")
+        rel_status = self.user.metadata.get("relationship_status")
         if not rel_status or rel_status == "" or rel_status.lower() == "skip":
             return await self.go_to_state("state_relationship_status")
         return await self.go_to_state("state_contentrepo_page")
@@ -295,7 +289,7 @@ class Application(BaseApplication):
                 "relationship_status": rel_status,
             }
 
-            await rapidpro.update_profile(whatsapp_id, data)
+            await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)
 
         return await self.go_to_state("state_contentrepo_page")
 
@@ -304,13 +298,13 @@ class Application(BaseApplication):
         whatsapp_id = msisdn.lstrip("+")
         timestamp = utils.get_current_datetime() + timedelta(minutes=10)
         # We ignore this error, as it just means they won't get the reminder
-        self.save_metadata("feedback_timestamp", timestamp.isoformat())
         await rapidpro.update_profile(
             whatsapp_id,
             {
                 "feedback_timestamp": timestamp.isoformat(),
                 "feedback_type": "content",
             },
+            self.user.metadata,
         )
 
         metadata = self.user.metadata

--- a/yal/onboarding.py
+++ b/yal/onboarding.py
@@ -22,7 +22,7 @@ class Application(BaseApplication):
             "onboarding_reminder_type": "5 min",
         }
 
-        return await rapidpro.update_profile(whatsapp_id, data)
+        return await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)
 
     async def state_persona_name(self):
         await self.update_last_onboarding_time()
@@ -214,7 +214,7 @@ class Application(BaseApplication):
             "onboarding_reminder_type": "",
         }
 
-        error = await rapidpro.update_profile(whatsapp_id, data)
+        error = await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)
         if error:
             return await self.go_to_state("state_error")
 
@@ -255,7 +255,7 @@ class Application(BaseApplication):
             "onboarding_reminder_type": "",
         }  # Reset the fields
 
-        error = await rapidpro.update_profile(whatsapp_id, data)
+        error = await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)
         if error:
             return await self.go_to_state("state_error")
 
@@ -286,7 +286,7 @@ class Application(BaseApplication):
             "last_onboarding_time": get_current_datetime().isoformat(),
         }
 
-        error = await rapidpro.update_profile(whatsapp_id, data)
+        error = await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)
         if error:
             return await self.go_to_state("state_error")
 
@@ -317,7 +317,7 @@ class Application(BaseApplication):
                 "onboarding_reminder_sent": "",  # Reset the field
             }
 
-            error = await rapidpro.update_profile(whatsapp_id, data)
+            error = await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)
             if error:
                 return await self.go_to_state("state_error")
             return await self.go_to_state("state_persona_name")

--- a/yal/optout.py
+++ b/yal/optout.py
@@ -78,6 +78,7 @@ class Application(BaseApplication):
         error = await rapidpro.update_profile(
             whatsapp_id,
             data,
+            self.user.metadata,
         )
         if error:
             return await self.go_to_state("state_error")
@@ -174,12 +175,9 @@ class Application(BaseApplication):
             "gender_other": "",
             "emergency_contact": "",
         } | self.reminders_to_be_cleared
-        error, fields = await rapidpro.get_profile(whatsapp_id)
-        if error:
-            return await self.go_to_state("state_error")
-        old_details = self.__get_user_details(fields)
+        old_details = self.__get_user_details(self.user.metadata)
 
-        error = await rapidpro.update_profile(whatsapp_id, data)
+        error = await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)
         if error:
             return await self.go_to_state("state_error")
 

--- a/yal/pleasecallme.py
+++ b/yal/pleasecallme.py
@@ -279,7 +279,7 @@ class Application(BaseApplication):
             "callback_check_time": call_time.isoformat(),
         }
 
-        error = await rapidpro.update_profile(whatsapp_id, data)
+        error = await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)
         if error:
             return await self.go_to_state("state_error")
 
@@ -432,7 +432,7 @@ class Application(BaseApplication):
             "emergency_contact": self.user.answers.get("state_specify_msisdn"),
         }
 
-        error = await rapidpro.update_profile(whatsapp_id, data)
+        error = await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)
         if error:
             return await self.go_to_state("state_error")
         return await self.go_to_state("state_submit_callback")
@@ -469,7 +469,7 @@ class Application(BaseApplication):
         data = {
             "last_mainmenu_time": get_current_datetime().isoformat(),
         }
-        error = await rapidpro.update_profile(whatsapp_id, data)
+        error = await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)
         if error:
             return await self.go_to_state("state_error")
 
@@ -718,13 +718,7 @@ class Application(BaseApplication):
         )
 
     async def state_offer_saved_emergency_contact(self):
-        msisdn = normalise_phonenumber(self.inbound.from_addr)
-        whatsapp_id = msisdn.lstrip(" + ")
-
-        error, fields = await rapidpro.get_profile(whatsapp_id)
-        if error:
-            return await self.go_to_state("state_error")
-        msisdn = fields.get("emergency_contact")
+        msisdn = self.user.metadata.get("emergency_contact")
         if msisdn:
             self.save_answer("state_specify_msisdn", msisdn)
 
@@ -836,7 +830,7 @@ class Application(BaseApplication):
             "callback_abandon_reason": "got help",
         }
 
-        error = await rapidpro.update_profile(whatsapp_id, data)
+        error = await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)
         if error:
             return await self.go_to_state("state_error")
 
@@ -875,7 +869,7 @@ class Application(BaseApplication):
             "callback_abandon_reason": "too long",
         }
 
-        error = await rapidpro.update_profile(whatsapp_id, data)
+        error = await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)
         if error:
             return await self.go_to_state("state_error")
         question = self._(
@@ -918,7 +912,7 @@ class Application(BaseApplication):
             "callback_abandon_reason": "changed mind",
         }
 
-        error = await rapidpro.update_profile(whatsapp_id, data)
+        error = await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)
         if error:
             return await self.go_to_state("state_error")
         question = self._(

--- a/yal/rapidpro.py
+++ b/yal/rapidpro.py
@@ -48,7 +48,14 @@ async def get_profile(whatsapp_id):
     return False, fields
 
 
-async def update_profile(whatsapp_id, fields):
+async def update_profile(whatsapp_id, fields, metadata):
+    """
+    Updates the user's profile on RapidPro.
+
+    whatsapp_id: The user's whatsapp URN path
+    fields: Keys are fields to update, values are values to update them to
+    metadata: The user's metadata. Used to keep cached contact in sync with RapidPro
+    """
     urn = f"whatsapp:{whatsapp_id}"
     async with get_rapidpro_api() as session:
         for i in range(3):
@@ -64,6 +71,8 @@ async def update_profile(whatsapp_id, fields):
                     json=params,
                 )
                 response.raise_for_status()
+                for key, value in fields.items():
+                    metadata[key] = value
                 break
             except HTTP_EXCEPTIONS as e:
                 if i == 2:

--- a/yal/servicefinder.py
+++ b/yal/servicefinder.py
@@ -329,13 +329,13 @@ class Application(BaseApplication):
     async def state_display_facilities(self):
         timestamp = utils.get_current_datetime() + self.SURVEY_DELAY
         whatsapp_id = utils.normalise_phonenumber(self.inbound.from_addr).lstrip("+")
-        self.save_metadata("feedback_timestamp", timestamp.isoformat())
         await rapidpro.update_profile(
             whatsapp_id=whatsapp_id,
             fields={
                 "feedback_timestamp": timestamp.isoformat(),
                 "feedback_type": "servicefinder",
             },
+            metadata=self.user.metadata,
         )
 
         metadata = self.user.metadata
@@ -549,7 +549,7 @@ class Application(BaseApplication):
             "longitude": longitude,
         }
 
-        await rapidpro.update_profile(whatsapp_id, data)
+        await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)
 
         return await self.go_to_state("state_category_lookup")
 

--- a/yal/terms_and_conditions.py
+++ b/yal/terms_and_conditions.py
@@ -169,7 +169,9 @@ class Application(BaseApplication):
         msisdn = normalise_phonenumber(self.inbound.from_addr)
         whatsapp_id = msisdn.lstrip(" + ")
 
-        error = await rapidpro.update_profile(whatsapp_id, {"terms_accepted": "True"})
+        error = await rapidpro.update_profile(
+            whatsapp_id, {"terms_accepted": "True"}, self.user.metadata
+        )
         if error:
             return await self.go_to_state("state_error")
 

--- a/yal/tests/test_askaquestion.py
+++ b/yal/tests/test_askaquestion.py
@@ -94,7 +94,7 @@ async def aaq_mock():
         config.AAQ_URL = url
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 async def rapidpro_mock():
     Sanic.test_mode = True
     app = Sanic("mock_rapidpro")
@@ -181,8 +181,8 @@ async def test_start_state_response_sets_timeout(
 
     tester.assert_state("state_display_results")
 
-    assert len(rapidpro_mock.tstate.requests) == 1
-    request = rapidpro_mock.tstate.requests[0]
+    assert len(rapidpro_mock.tstate.requests) == 2
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "feedback_timestamp": "2022-06-19T17:35:00",
@@ -252,8 +252,8 @@ async def test_state_display_results_choose_an_answer(
 
     tester.assert_state("state_get_content_feedback")
 
-    assert len(rapidpro_mock.tstate.requests) == 1
-    request = rapidpro_mock.tstate.requests[0]
+    assert len(rapidpro_mock.tstate.requests) == 2
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "feedback_timestamp": "2022-06-19T17:35:00",
@@ -348,8 +348,8 @@ async def test_state_display_results_no_answers(
     tester.assert_state("state_aaq_start")
     tester.assert_answer("state_no_answers", "empty")
 
-    assert len(rapidpro_mock.tstate.requests) == 1
-    request = rapidpro_mock.tstate.requests[0]
+    assert len(rapidpro_mock.tstate.requests) == 2
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "feedback_timestamp": "2022-06-19T17:35:00",
@@ -434,8 +434,8 @@ async def test_state_get_content_feedback_question_answered(
 
     tester.assert_state("state_yes_question_answered")
 
-    assert len(rapidpro_mock.tstate.requests) == 1
-    request = rapidpro_mock.tstate.requests[0]
+    assert len(rapidpro_mock.tstate.requests) == 2
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {"feedback_type": ""},
     }

--- a/yal/tests/test_change_preferences.py
+++ b/yal/tests/test_change_preferences.py
@@ -38,7 +38,7 @@ def get_rapidpro_contact(urn):
     }
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 async def rapidpro_mock():
     Sanic.test_mode = True
     app = Sanic("mock_rapidpro")
@@ -224,7 +224,7 @@ async def test_state_update_gender_from_list(tester: AppTester, rapidpro_mock):
 
     tester.assert_state("state_update_gender_confirm")
 
-    assert [r.path for r in rapidpro_mock.tstate.requests] == []
+    assert [r.method for r in rapidpro_mock.tstate.requests] == ["GET"]
 
 
 @pytest.mark.asyncio
@@ -260,7 +260,7 @@ async def test_state_update_other_gender(tester: AppTester, rapidpro_mock):
 
     tester.assert_answer("state_update_gender", "other")
 
-    assert [r.path for r in rapidpro_mock.tstate.requests] == []
+    assert [r.method for r in rapidpro_mock.tstate.requests] == ["GET"]
 
 
 @pytest.mark.asyncio
@@ -275,7 +275,7 @@ async def test_state_update_gender_confirm(tester: AppTester, rapidpro_mock):
 
     tester.assert_answer("state_update_other_gender", "trans man")
 
-    assert [r.path for r in rapidpro_mock.tstate.requests] == []
+    assert [r.method for r in rapidpro_mock.tstate.requests] == ["GET"]
 
 
 @pytest.mark.asyncio
@@ -290,7 +290,7 @@ async def test_state_update_gender_confirm_not_correct(
     tester.assert_state("state_update_gender")
     tester.assert_num_messages(1)
 
-    assert [r.path for r in rapidpro_mock.tstate.requests] == []
+    assert [r.method for r in rapidpro_mock.tstate.requests] == ["GET"]
 
 
 @pytest.mark.asyncio
@@ -338,7 +338,7 @@ async def test_state_update_age_confirm(tester: AppTester, rapidpro_mock):
     tester.assert_num_messages(1)
     tester.assert_state("state_update_age_confirm")
 
-    assert [r.path for r in rapidpro_mock.tstate.requests] == []
+    assert [r.method for r in rapidpro_mock.tstate.requests] == ["GET"]
 
 
 @pytest.mark.asyncio
@@ -349,7 +349,7 @@ async def test_state_update_age_confirm_not_correct(tester: AppTester, rapidpro_
     tester.assert_num_messages(1)
     tester.assert_state("state_update_age")
 
-    assert [r.path for r in rapidpro_mock.tstate.requests] == []
+    assert [r.method for r in rapidpro_mock.tstate.requests] == ["GET"]
 
 
 @pytest.mark.asyncio
@@ -376,7 +376,7 @@ async def test_state_update_relationship_status(tester: AppTester, rapidpro_mock
                 "*CHAT SETTINGS / ⚙️ Change or update your info* / *Relationship?*",
                 "-----",
                 "",
-                "🤖 *Are you currently in a relationship or seeing "
+                "🦸 *Are you currently in a relationship or seeing "
                 "someone special right now?",
                 "",
                 "1. Yes, in relationship",
@@ -399,7 +399,7 @@ async def test_state_update_relationship_status_confirm(
     tester.assert_num_messages(1)
     tester.assert_state("state_update_relationship_status_confirm")
 
-    assert [r.path for r in rapidpro_mock.tstate.requests] == []
+    assert [r.method for r in rapidpro_mock.tstate.requests] == ["GET"]
 
 
 @pytest.mark.asyncio
@@ -412,7 +412,7 @@ async def test_state_update_relationship_status_confirm_not_correct(
     tester.assert_num_messages(1)
     tester.assert_state("state_update_relationship_status")
 
-    assert [r.path for r in rapidpro_mock.tstate.requests] == []
+    assert [r.method for r in rapidpro_mock.tstate.requests] == ["GET"]
 
 
 @pytest.mark.asyncio
@@ -425,9 +425,7 @@ async def test_state_update_relationship_status_submit(
     tester.assert_num_messages(1)
     tester.assert_state("state_conclude_changes")
 
-    assert [r.path for r in rapidpro_mock.tstate.requests] == [
-        "/api/v2/contacts.json",
-    ]
+    assert [r.method for r in rapidpro_mock.tstate.requests] == ["GET", "POST"]
 
 
 @pytest.mark.asyncio
@@ -492,9 +490,7 @@ async def test_state_update_bot_name_submit(tester: AppTester, rapidpro_mock):
     tester.assert_state("state_update_bot_emoji")
     tester.assert_metadata("persona_name", "johnny")
 
-    assert [r.path for r in rapidpro_mock.tstate.requests] == [
-        "/api/v2/contacts.json",
-    ]
+    assert [r.method for r in rapidpro_mock.tstate.requests] == ["GET", "POST"]
 
 
 @pytest.mark.asyncio
@@ -524,7 +520,7 @@ async def test_state_update_bot_name_skip(tester: AppTester, rapidpro_mock):
     tester.assert_state("state_update_bot_emoji")
     tester.assert_metadata("persona_name", "Caped Crusader")
 
-    assert [r.path for r in rapidpro_mock.tstate.requests] == []
+    assert [r.method for r in rapidpro_mock.tstate.requests] == ["GET"]
 
 
 @pytest.mark.asyncio
@@ -554,9 +550,7 @@ async def test_state_update_bot_emoji_submit(tester: AppTester, rapidpro_mock):
     tester.assert_state("state_update_bot_emoji_submit")
     tester.assert_metadata("persona_emoji", "🙋🏿‍♂️")
 
-    assert [r.path for r in rapidpro_mock.tstate.requests] == [
-        "/api/v2/contacts.json",
-    ]
+    assert [r.method for r in rapidpro_mock.tstate.requests] == ["GET", "POST"]
 
 
 @pytest.mark.asyncio
@@ -569,9 +563,7 @@ async def test_state_update_bot_emoji_skip(tester: AppTester, rapidpro_mock):
     tester.assert_state("state_display_preferences")
     tester.assert_metadata("persona_emoji", "🦸")
 
-    assert [r.path for r in rapidpro_mock.tstate.requests] == [
-        "/api/v2/contacts.json",
-    ]
+    assert [r.method for r in rapidpro_mock.tstate.requests] == ["GET"]
 
 
 @pytest.mark.asyncio
@@ -586,11 +578,11 @@ async def test_state_update_location_confirm(tester: AppTester, google_api_mock)
     )
     tester.assert_state("state_update_location_confirm")
 
-    tester.assert_metadata("latitude", 56.78)
-    tester.assert_metadata("longitude", 12.34)
+    tester.assert_metadata("new_latitude", 56.78)
+    tester.assert_metadata("new_longitude", 12.34)
     tester.assert_metadata("place_id", "ChIJd8BlQ2BZwokRAFUEcm_qrcA")
     tester.assert_metadata(
-        "location_description", "277 Bedford Avenue, Brooklyn, NY 11211, USA"
+        "new_location_description", "277 Bedford Avenue, Brooklyn, NY 11211, USA"
     )
 
     assert [r.path for r in google_api_mock.tstate.requests] == [
@@ -643,9 +635,11 @@ async def test_state_update_location_confirm_incorrect(
 
 @pytest.mark.asyncio
 async def test_state_update_location_submit(tester: AppTester, rapidpro_mock):
-    tester.user.metadata["latitude"] = 56.78
-    tester.user.metadata["longitude"] = 12.34
-    tester.user.metadata["location_description"] = "277 Bedford Avenue, Brooklyn, NY"
+    tester.user.metadata["new_latitude"] = 56.78
+    tester.user.metadata["new_longitude"] = 12.34
+    tester.user.metadata[
+        "new_location_description"
+    ] = "277 Bedford Avenue, Brooklyn, NY"
     tester.setup_state("state_update_location_confirm")
 
     await tester.user_input("yes")
@@ -653,8 +647,8 @@ async def test_state_update_location_submit(tester: AppTester, rapidpro_mock):
     tester.assert_num_messages(1)
     tester.assert_state("state_conclude_changes")
 
-    assert len(rapidpro_mock.tstate.requests) == 1
-    request = rapidpro_mock.tstate.requests[0]
+    assert len(rapidpro_mock.tstate.requests) == 2
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "latitude": 56.78,

--- a/yal/tests/test_main.py
+++ b/yal/tests/test_main.py
@@ -106,7 +106,7 @@ def get_rapidpro_contact(urn):
         "groups": [],
         "fields": {
             "onboarding_completed": "27820001001" in urn,
-            "onboarding_reminder_sent": "27820001001" in urn,
+            "onboarding_reminder_sent": "27820001008" in urn,
             "terms_accepted": "27820001001" in urn,
             "province": "FS",
             "suburb": "cape town",
@@ -193,7 +193,7 @@ async def aaq_mock():
         config.AAQ_URL = url
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 async def rapidpro_mock():
     Sanic.test_mode = True
     app = Sanic("mock_rapidpro")
@@ -349,7 +349,7 @@ async def test_tracked_keywords_saved(
 async def test_tracked_keywords_saved_for_new_user(
     tester: AppTester, rapidpro_mock, contentrepo_api_mock
 ):
-    tester.setup_user_address("27820001002")
+    tester.setup_user_address("27820001000")
     await tester.user_input("heita")
     tester.assert_state("state_welcome")
     tester.assert_num_messages(1)
@@ -361,6 +361,7 @@ async def test_tracked_keywords_saved_for_new_user(
 async def test_onboarding_reminder_response_to_reminder_handler(
     tester: AppTester, rapidpro_mock
 ):
+    tester.setup_user_address("27820001008")
     await tester.user_input(session=Message.SESSION_EVENT.NEW, content="not interested")
     tester.assert_state("state_stop_onboarding_reminders")
     tester.assert_num_messages(1)
@@ -406,7 +407,7 @@ async def test_aaq_timeout_response_to_handler(
     )
     tester.assert_message(message)
 
-    assert len(rapidpro_mock.tstate.requests) == 4
+    assert len(rapidpro_mock.tstate.requests) == 3
 
 
 @pytest.mark.asyncio
@@ -452,7 +453,7 @@ async def test_servicefinder_feedback_response(tester: AppTester, rapidpro_mock)
     tester.assert_state("state_servicefinder_positive_feedback")
     tester.assert_num_messages(1)
 
-    assert len(rapidpro_mock.tstate.requests) == 3
+    assert len(rapidpro_mock.tstate.requests) == 2
 
 
 @pytest.mark.asyncio
@@ -467,7 +468,7 @@ async def test_servicefinder_feedback_2_response(tester: AppTester, rapidpro_moc
     tester.assert_state("state_went_to_service")
     tester.assert_num_messages(1)
 
-    assert len(rapidpro_mock.tstate.requests) == 3
+    assert len(rapidpro_mock.tstate.requests) == 2
 
 
 @pytest.mark.asyncio

--- a/yal/tests/test_mainmenu.py
+++ b/yal/tests/test_mainmenu.py
@@ -421,15 +421,15 @@ async def test_state_mainmenu_start(
         "/api/v2/pages/777",
     ]
 
-    assert len(rapidpro_mock.tstate.requests) == 2
-    request = rapidpro_mock.tstate.requests[0]
+    assert len(rapidpro_mock.tstate.requests) == 3
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "last_mainmenu_time": "2022-06-19T17:30:00",
             "suggested_text": "*12* - Suggested Content 1\n*13* - Suggested Content 2",
         },
     }
-    request = rapidpro_mock.tstate.requests[1]
+    request = rapidpro_mock.tstate.requests[2]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "feedback_timestamp": "2022-06-19T19:30:00",
@@ -494,8 +494,8 @@ async def test_state_mainmenu_start_suggested_populated(
         "/api/v2/pages",
     ]
 
-    assert len(rapidpro_mock.tstate.requests) == 1
-    request = rapidpro_mock.tstate.requests[0]
+    assert len(rapidpro_mock.tstate.requests) == 2
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "last_mainmenu_time": "2022-06-19T17:30:00",
@@ -523,7 +523,7 @@ async def test_state_mainmenu_static(
         "/api/v2/pages",
     ]
 
-    assert len(rapidpro_mock.tstate.requests) == 2
+    assert len(rapidpro_mock.tstate.requests) == 3
 
 
 @pytest.mark.asyncio
@@ -546,7 +546,7 @@ async def test_state_mainmenu_aaq(
         "/api/v2/pages",
     ]
 
-    assert len(rapidpro_mock.tstate.requests) == 2
+    assert len(rapidpro_mock.tstate.requests) == 3
 
 
 @pytest.mark.asyncio
@@ -585,8 +585,8 @@ async def test_state_mainmenu_contentrepo(
 
     tester.assert_metadata("topics_viewed", ["111"])
 
-    assert len(rapidpro_mock.tstate.requests) == 4
-    request = rapidpro_mock.tstate.requests[1]
+    assert len(rapidpro_mock.tstate.requests) == 5
+    request = rapidpro_mock.tstate.requests[2]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "last_mainmenu_time": "",
@@ -639,8 +639,8 @@ async def test_state_mainmenu_contentrepo_help_content(
     request = contentrepo_api_mock.tstate.requests[-1]
     assert request.args["message"] == ["2"]
 
-    assert len(rapidpro_mock.tstate.requests) == 7
-    request = rapidpro_mock.tstate.requests[1]
+    assert len(rapidpro_mock.tstate.requests) == 9
+    request = rapidpro_mock.tstate.requests[2]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "last_mainmenu_time": "",
@@ -692,7 +692,7 @@ async def test_state_mainmenu_contentrepo_relationship_content_rel_set(
     tester.assert_metadata("topics_viewed", ["222"])
 
     assert len(rapidpro_mock.tstate.requests) == 5
-    request = rapidpro_mock.tstate.requests[1]
+    request = rapidpro_mock.tstate.requests[2]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "last_mainmenu_time": "",
@@ -742,7 +742,7 @@ async def test_state_mainmenu_contentrepo_relationship_status(
     tester.assert_metadata("topics_viewed", ["222"])
 
     assert len(rapidpro_mock.tstate.requests) == 3
-    request = rapidpro_mock.tstate.requests[1]
+    request = rapidpro_mock.tstate.requests[2]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "last_mainmenu_time": "",
@@ -796,7 +796,7 @@ async def test_state_mainmenu_contentrepo_relationship_skip(
         "/api/v2/pages",
     ]
 
-    assert len(rapidpro_mock.tstate.requests) == 2
+    assert len(rapidpro_mock.tstate.requests) == 3
 
 
 @pytest.mark.asyncio
@@ -844,8 +844,8 @@ async def test_state_mainmenu_contentrepo_relationship_submit(
         "/api/v2/pages",
     ]
 
-    assert len(rapidpro_mock.tstate.requests) == 3
-    request = rapidpro_mock.tstate.requests[0]
+    assert len(rapidpro_mock.tstate.requests) == 4
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "relationship_status": "yes",
@@ -924,7 +924,7 @@ async def test_state_mainmenu_contentrepo_children(
     assert params["data__session_id"][0] == "1"
     assert params["data__user_addr"][0] == "27820001001"
 
-    assert len(rapidpro_mock.tstate.requests) == 7
+    assert len(rapidpro_mock.tstate.requests) == 9
 
     update_request = rapidpro_mock.tstate.requests[-1]
     assert update_request.json["fields"] == {

--- a/yal/tests/test_onboarding.py
+++ b/yal/tests/test_onboarding.py
@@ -19,7 +19,7 @@ def tester():
 def get_rapidpro_contact(urn):
     return {
         "fields": {
-            "onboarding_reminder_sent": "True",
+            "onboarding_reminder_sent": "True" if "27820001002" in urn else "False",
         },
     }
 
@@ -82,8 +82,8 @@ async def test_state_persona_name(
         ]
     )
 
-    assert len(rapidpro_mock.tstate.requests) == 2
-    request = rapidpro_mock.tstate.requests[0]
+    assert len(rapidpro_mock.tstate.requests) == 3
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "last_onboarding_time": "2022-06-19T17:30:00",
@@ -105,8 +105,8 @@ async def test_state_persona_name_skip(
     tester.assert_state("state_age")
     tester.assert_num_messages(1)
 
-    assert len(rapidpro_mock.tstate.requests) == 2
-    request = rapidpro_mock.tstate.requests[0]
+    assert len(rapidpro_mock.tstate.requests) == 3
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "last_onboarding_time": "2022-06-19T17:30:00",
@@ -130,8 +130,8 @@ async def test_state_persona_emoji(
 
     tester.assert_metadata("persona_emoji", "😉")
 
-    assert len(rapidpro_mock.tstate.requests) == 2
-    request = rapidpro_mock.tstate.requests[0]
+    assert len(rapidpro_mock.tstate.requests) == 3
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "last_onboarding_time": "2022-06-19T17:30:00",
@@ -155,8 +155,8 @@ async def test_state_persona_emoji_skip(
 
     assert "persona_emoji" not in tester.user.metadata
 
-    assert len(rapidpro_mock.tstate.requests) == 2
-    request = rapidpro_mock.tstate.requests[0]
+    assert len(rapidpro_mock.tstate.requests) == 3
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "last_onboarding_time": "2022-06-19T17:30:00",
@@ -178,8 +178,8 @@ async def test_state_age(get_current_datetime, tester: AppTester, rapidpro_mock)
 
     tester.assert_answer("state_age", "22")
 
-    assert len(rapidpro_mock.tstate.requests) == 2
-    request = rapidpro_mock.tstate.requests[0]
+    assert len(rapidpro_mock.tstate.requests) == 3
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "last_onboarding_time": "2022-06-19T17:30:00",
@@ -201,8 +201,8 @@ async def test_state_age_skip(get_current_datetime, tester: AppTester, rapidpro_
 
     tester.assert_answer("state_age", "Skip")
 
-    assert len(rapidpro_mock.tstate.requests) == 2
-    request = rapidpro_mock.tstate.requests[0]
+    assert len(rapidpro_mock.tstate.requests) == 3
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "last_onboarding_time": "2022-06-19T17:30:00",
@@ -239,8 +239,8 @@ async def test_state_gender(get_current_datetime, tester: AppTester, rapidpro_mo
         )
     )
 
-    assert len(rapidpro_mock.tstate.requests) == 1
-    request = rapidpro_mock.tstate.requests[0]
+    assert len(rapidpro_mock.tstate.requests) == 2
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "last_onboarding_time": "2022-06-19T17:30:00",
@@ -266,8 +266,8 @@ async def test_state_gender_from_list(
 
     tester.assert_answer("state_gender", "male")
 
-    assert len(rapidpro_mock.tstate.requests) == 3
-    request = rapidpro_mock.tstate.requests[0]
+    assert len(rapidpro_mock.tstate.requests) == 4
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "last_onboarding_time": "2022-06-19T17:30:00",
@@ -289,8 +289,8 @@ async def test_state_other_gender(
     tester.assert_state("state_other_gender")
     tester.assert_num_messages(1)
 
-    assert len(rapidpro_mock.tstate.requests) == 2
-    request = rapidpro_mock.tstate.requests[0]
+    assert len(rapidpro_mock.tstate.requests) == 3
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "last_onboarding_time": "2022-06-19T17:30:00",
@@ -322,7 +322,7 @@ async def test_submit_onboarding(mock_config, tester: AppTester, rapidpro_mock):
                 "",
                 "-----",
                 "",
-                "🤖  *Do you want to go ahead and ask a question?*",
+                "⛑️  *Do you want to go ahead and ask a question?*",
                 "I can answer questions about sex, relationships and your health. "
                 "Just type your Q and hit send 🙂",
                 "",
@@ -336,8 +336,8 @@ async def test_submit_onboarding(mock_config, tester: AppTester, rapidpro_mock):
         buttons=["Main menu"],
     )
 
-    assert len(rapidpro_mock.tstate.requests) == 2
-    request = rapidpro_mock.tstate.requests[1]
+    assert len(rapidpro_mock.tstate.requests) == 3
+    request = rapidpro_mock.tstate.requests[2]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "age": "22",

--- a/yal/tests/test_optout.py
+++ b/yal/tests/test_optout.py
@@ -62,7 +62,7 @@ def get_rapidpro_contact(urn):
     return contact
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 async def rapidpro_mock():
     Sanic.test_mode = True
     app = Sanic("mock_rapidpro")
@@ -109,7 +109,7 @@ async def test_state_optout(tester: AppTester):
     tester.assert_message(
         "\n".join(
             [
-                "🤖 *Hi!*",
+                "🦁 *Hi!*",
                 "",
                 "I just received a message from you saying *stop*.",
                 "",
@@ -186,11 +186,13 @@ async def test_state_optout_stop_notifications(tester: AppTester, rapidpro_mock)
     await tester.user_input("1")
     tester.assert_state("state_optout_survey")
 
-    assert len(rapidpro_mock.tstate.requests) == 1
+    assert len(rapidpro_mock.tstate.requests) == 2
 
-    assert [r.path for r in rapidpro_mock.tstate.requests] == ["/api/v2/contacts.json"]
+    assert [r.path for r in rapidpro_mock.tstate.requests] == [
+        "/api/v2/contacts.json"
+    ] * 2
 
-    post_request = rapidpro_mock.tstate.requests[0]
+    post_request = rapidpro_mock.tstate.requests[1]
     assert json.loads(post_request.body.decode("utf-8")) == {
         "fields": {
             "last_main_time": "",

--- a/yal/tests/test_segmentation_survey.py
+++ b/yal/tests/test_segmentation_survey.py
@@ -30,7 +30,7 @@ def get_rapidpro_contact(urn):
     }
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 async def rapidpro_mock():
     Sanic.test_mode = True
     app = Sanic("mock_rapidpro")
@@ -413,8 +413,8 @@ async def test_state_survey_done(tester: AppTester, rapidpro_mock):
         )
     )
 
-    assert len(rapidpro_mock.tstate.requests) == 1
-    request = rapidpro_mock.tstate.requests[0]
+    assert len(rapidpro_mock.tstate.requests) == 2
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "flow": "segment-airtime-flow-uuid",
         "urns": ["whatsapp:27820001001"],

--- a/yal/tests/test_servicefinder.py
+++ b/yal/tests/test_servicefinder.py
@@ -167,7 +167,7 @@ async def google_api_mock():
         config.GOOGLE_PLACES_URL = url
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 async def rapidpro_mock():
     Sanic.test_mode = True
     app = Sanic("mock_rapidpro")

--- a/yal/tests/test_servicefinder_feedback_survey.py
+++ b/yal/tests/test_servicefinder_feedback_survey.py
@@ -12,7 +12,10 @@ from yal.servicefinder_feedback_survey import ServiceFinderFeedbackSurveyApplica
 
 @pytest.fixture
 def tester():
-    return AppTester(ServiceFinderFeedbackSurveyApplication)
+    tester = AppTester(ServiceFinderFeedbackSurveyApplication)
+    tester.user.metadata["feedback_timestamp"] = "2022-03-04T05:06:07"
+    tester.user.metadata["feedback_timestamp_2"] = "2022-03-04T05:06:07"
+    return tester
 
 
 @pytest.fixture
@@ -20,23 +23,6 @@ async def rapidpro_mock():
     Sanic.test_mode = True
     app = Sanic("mock_rapidpro")
     tstate = TState()
-
-    @app.route("/api/v2/contacts.json", methods=["GET"])
-    def get_contact(request):
-        tstate.requests.append(request)
-        return response.json(
-            {
-                "results": [
-                    {
-                        "fields": {
-                            "feedback_timestamp": "2022-03-04T05:06:07",
-                            "feedback_timestamp_2": "2022-03-04T05:06:07",
-                        }
-                    }
-                ]
-            },
-            status=200,
-        )
 
     @app.route("/api/v2/contacts.json", methods=["POST"])
     def update_contact(request):
@@ -135,7 +121,7 @@ async def test_state_went_to_service(tester: AppTester, rapidpro_mock: MockServe
     await tester.user_input("yes, i went")
     tester.assert_state("state_went_to_service")
     assert rapidpro_mock.tstate is not None
-    assert len(rapidpro_mock.tstate.requests) == 2
+    assert len(rapidpro_mock.tstate.requests) == 1
 
 
 @pytest.mark.asyncio
@@ -146,7 +132,7 @@ async def test_state_did_not_go_to_service(
     await tester.user_input("no, i didn't go")
     tester.assert_state("state_did_not_go_to_service")
     assert rapidpro_mock.tstate is not None
-    assert len(rapidpro_mock.tstate.requests) == 2
+    assert len(rapidpro_mock.tstate.requests) == 1
 
 
 @pytest.mark.asyncio

--- a/yal/tests/test_terms_and_conditions.py
+++ b/yal/tests/test_terms_and_conditions.py
@@ -13,7 +13,7 @@ def tester():
     return AppTester(Application)
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 async def rapidpro_mock():
     Sanic.test_mode = True
     app = Sanic("mock_rapidpro")

--- a/yal/tests/test_usertest_feedback.py
+++ b/yal/tests/test_usertest_feedback.py
@@ -319,8 +319,8 @@ async def test_state_submit_completed_feedback(tester: AppTester, rapidpro_mock)
         )
     )
 
-    assert len(rapidpro_mock.tstate.requests) == 1
-    request = rapidpro_mock.tstate.requests[0]
+    assert len(rapidpro_mock.tstate.requests) == 2
+    request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
         "flow": "usertesting-flow-uid",
         "urns": ["whatsapp:27820001001"],

--- a/yal/usertest_feedback.py
+++ b/yal/usertest_feedback.py
@@ -8,16 +8,9 @@ class Application(BaseApplication):
     START_STATE = "state_check_feedback"
 
     async def state_check_feedback(self):
-        msisdn = utils.normalise_phonenumber(self.inbound.from_addr)
-        whatsapp_id = msisdn.lstrip(" + ")
-
-        error, fields = await rapidpro.get_profile(whatsapp_id)
-        if error:
-            return await self.go_to_state("state_error")
-
-        if fields.get("usertesting_feedback_complete") == "PENDING":
+        if self.user.metadata.get("usertesting_feedback_complete") == "PENDING":
             return await self.go_to_state("state_feedback_pleasecallme")
-        elif fields.get("usertesting_feedback_complete") == "TRUE":
+        elif self.user.metadata.get("usertesting_feedback_complete") == "TRUE":
             return await self.go_to_state("state_already_completed")
         else:
             return await self.go_to_state("state_catch_all")

--- a/yal/wa_fb_crossover_feedback.py
+++ b/yal/wa_fb_crossover_feedback.py
@@ -27,9 +27,10 @@ class Application(BaseApplication):
         msisdn = utils.normalise_phonenumber(self.inbound.from_addr)
         whatsapp_id = msisdn.lstrip("+")
         # Reset this, so that we only get the survey once after a push
-        self.save_metadata("feedback_timestamp", "")
         await rapidpro.update_profile(
-            whatsapp_id, {"feedback_survey_sent": "", "feedback_timestamp": ""}
+            whatsapp_id,
+            {"feedback_survey_sent": "", "feedback_timestamp": ""},
+            self.user.metadata,
         )
         keyword = utils.clean_inbound(self.inbound.content)
         if keyword in self.WA_FB_CROSSOVER_TRIGGER_KEYWORDS:
@@ -107,7 +108,7 @@ class Application(BaseApplication):
             "engaged_on_facebook": "TRUE",
             "last_mainmenu_time": utils.get_current_datetime().isoformat(),
         }
-        error = await rapidpro.update_profile(whatsapp_id, data)
+        error = await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)
         if error:
             return await self.go_to_state("state_error")
 
@@ -156,7 +157,7 @@ class Application(BaseApplication):
         data = {
             "engaged_on_facebook": "FALSE",
         }
-        error = await rapidpro.update_profile(whatsapp_id, data)
+        error = await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)
         if error:
             return await self.go_to_state("state_error")
 


### PR DESCRIPTION
Previously we fetched the RapidPro contact when we thought we might need it, by keeping a timestamp locally, and checking when we got close to the timestamp. This is complicated, and won't work for some future changes that we want to do, so this PR changes to fetching the RapidPro contact fields on every inbound message, and storing them on the user metadata
