### PR TITLE
Use contact fields for segmentation survey trigger

### DIFF
--- a/vaccine/testing.py
+++ b/vaccine/testing.py
@@ -190,6 +190,7 @@ class TState:
     errors: int = 0
     errormax: int = 0
     banner: bool = False
+    contact_fields: dict = field(default_factory=dict)
 
 
 def unused_port():

--- a/yal/main.py
+++ b/yal/main.py
@@ -104,20 +104,6 @@ class Application(
             self.user.session_id = None
             self.state_name = "state_qa_reset_feedback_timestamp_keywords"
 
-        if keyword in SEGMENT_SURVEY_ACCEPT or keyword in SEGMENT_SURVEY_DECLINE:
-            segment_survey_complete = self.user.metadata.get(
-                "segment_survey_complete", "false"
-            ).lower()
-            if segment_survey_complete == "pending":
-                self.user.session_id = None
-                if keyword in SEGMENT_SURVEY_ACCEPT:
-                    self.state_name = SegmentSurveyApplication.START_STATE
-                else:
-                    self.state_name = SegmentSurveyApplication.DECLINE_STATE
-            elif segment_survey_complete == "true":
-                self.user.session_id = None
-                self.state_name = SegmentSurveyApplication.COMPLETED_STATE
-
         if keyword in ONBOARDING_REMINDER_KEYWORDS:
             if self.user.metadata.get("onboarding_reminder_sent"):
                 self.user.session_id = None
@@ -130,6 +116,14 @@ class Application(
                 self.user.session_id = random_id()
             message.session_event = Message.SESSION_EVENT.RESUME
             self.state_name = feedback_state
+
+        segment_survey_complete = self.user.metadata.get(
+            "segment_survey_complete", "false"
+        ).lower()
+        if segment_survey_complete == "pending":
+            if self.state_name not in dir(SegmentSurveyApplication):
+                self.user.session_id = None
+                self.state_name = SegmentSurveyApplication.START_STATE
 
         return await super().process_message(message)
 


### PR DESCRIPTION
Previously it used keywords, which was problematic if the user sent `1` instead if `Hell yeah!`, but also problematic with features that need to be added. Now it uses contact fields from RapidPro.

It also updates the rapidpro mock for the segment survey to be a bit easier to assert on
