### PR TITLE
Fix None metadata

### DIFF
--- a/yal/main.py
+++ b/yal/main.py
@@ -73,7 +73,10 @@ class Application(
         if error:
             return await self.go_to_state("state_error")
         for key, value in fields.items():
-            self.save_metadata(key, value)
+            if value:
+                self.save_metadata(key, value)
+            else:
+                self.delete_metadata(key)
 
         keyword = utils.clean_inbound(message.content)
         # Restart keywords that interrupt the current flow

--- a/yal/utils.py
+++ b/yal/utils.py
@@ -75,8 +75,9 @@ def normalise_phonenumber(phonenumber):
 
 def replace_persona_fields(text, metadata={}):
     for key in PERSONA_FIELDS:
-        if key in metadata and metadata[key].lower() != "skip":
-            text = text.replace(f"[{key}]", metadata[key])
+        value = metadata.get(key)
+        if value and value.lower() != "skip":
+            text = text.replace(f"[{key}]", value)
         else:
             text = text.replace(f"[{key}]", PERSONA_DEFAULTS[key])
     return text


### PR DESCRIPTION
This started off as a fix for the one error I was seeing, which was that metadata fields could be None, and so you can't call lower on them for the replace_persona_fields function.

It turned into a bit of a rework, firstly to make testing a bit easier in test_main, and secondly to only save a rapidpro contact field to metadata if it has a value (which should also help if we're making this metadata can't be none assumption anywhere else)

