### PR TITLE
YAL: add onboarding and assessments content

### DIFF
--- a/yal/assessment_data/sexual_health_literacy.py
+++ b/yal/assessment_data/sexual_health_literacy.py
@@ -1,4 +1,4 @@
-SURVEY_QUESTIONS = {
+ASSESSMENT_QUESTIONS = {
     "1": {
         "start": "state_s1_1_sex_health_lit_sti",
         "questions": {

--- a/yal/assessment_data/sexual_health_literacy.py
+++ b/yal/assessment_data/sexual_health_literacy.py
@@ -3,7 +3,7 @@ ASSESSMENT_QUESTIONS = {
         "start": "state_s1_1_sex_health_lit_sti",
         "questions": {
             "state_s1_1_sex_health_lit_sti": {
-                "type": "freetext",
+                "type": "choice",
                 "text": "\n".join(
                     [
                         "*_People can reduce the risk of getting STIs by:_*",
@@ -11,17 +11,23 @@ ASSESSMENT_QUESTIONS = {
                         "[persona_emoji] _Reply with the *number* "
                         "of your chosen answer:_",
                         "",
-                        "*1.* using to condoms every time they "
-                        "have sexual intercourse.",
-                        "",
-                        "*2.* only having sex with one partner who "
-                        "isn't infected and who has no other partners.",
                     ]
                 ),
+                "options": [
+                    (
+                        "condoms",
+                        "using to condoms every time they have sexual intercourse.",
+                    ),
+                    (
+                        "single_partner",
+                        "only having sex with one partner who isn't infected and who "
+                        "has no other partners.",
+                    ),
+                ],
                 "next": "state_s1_2_sex_health_lit_consent",
             },
             "state_s1_2_sex_health_lit_consent": {
-                "type": "freetext",
+                "type": "choice",
                 "text": "\n".join(
                     [
                         "*If Teddy goes out to a restaurant and starts chatting "
@@ -32,18 +38,20 @@ ASSESSMENT_QUESTIONS = {
                         "[persona_emoji] _Reply with the *number* "
                         "of your chosen answer:_",
                         "",
-                        "*1*. By the way they are looking at him",
-                        "*2*. By what they are wearing",
-                        "*3*. If they carry condoms",
-                        "*4*. If Teddy has had sex with them before",
-                        "*5*. If they verbally consent to have sex",
-                        "*6*. I don't know",
                     ]
                 ),
+                "options": [
+                    ("looking", "By the way they are looking at him"),
+                    ("wearing", "By what they are wearing"),
+                    ("condoms", "If they carry condoms"),
+                    ("previous_sex", "If Teddy has had sex with them before"),
+                    ("verbal_consent", "If they verbally consent to have sex"),
+                    ("dont_know", "I don't know"),
+                ],
                 "next": "state_s1_3_sex_health_lit_right_to_sex",
             },
             "state_s1_3_sex_health_lit_right_to_sex": {
-                "type": "choice",
+                "type": "list",
                 "text": "\n".join(
                     [
                         "*Robert and Samantha have been dating for 5 years and love "
@@ -71,7 +79,7 @@ ASSESSMENT_QUESTIONS = {
                 "next": "state_s1_4_sex_health_lit_insist_condoms",
             },
             "state_s1_4_sex_health_lit_insist_condoms": {
-                "type": "choice",
+                "type": "list",
                 "text": "\n".join(
                     [
                         "How much do you agree or disagree with "
@@ -92,7 +100,7 @@ ASSESSMENT_QUESTIONS = {
                 "next": "state_s1_5_sex_health_lit_saying_no",
             },
             "state_s1_5_sex_health_lit_saying_no": {
-                "type": "freetext",
+                "type": "choice",
                 "text": "\n".join(
                     [
                         "*If you are in a relationship, which statement describes you "
@@ -101,19 +109,30 @@ ASSESSMENT_QUESTIONS = {
                         "[persona_emoji] _Reply with the *number* "
                         "of your chosen answer:_",
                         "",
-                        "*1.* I'm cool with telling bae no if they want "
-                        "to have sex but I don't.",
-                        "*2.* I find it hard to say no to bae if bae wants "
-                        "to have sex but I don't.",
-                        "*3.* I'm not sure how I feel about saying no when "
-                        "bae wants to have sex and I don't.",
-                        "*4.* I'm not in a relationship",
                     ]
                 ),
+                "options": [
+                    (
+                        "easy",
+                        "I'm cool with telling bae no if they want to have sex but I "
+                        "don't.",
+                    ),
+                    (
+                        "difficult",
+                        "I find it hard to say no to bae if bae wants to have sex but "
+                        "I don't.",
+                    ),
+                    (
+                        "not_sure",
+                        "I'm not sure how I feel about saying no when bae wants to "
+                        "have sex and I don't.",
+                    ),
+                    ("no_relationship", "I'm not in a relationship"),
+                ],
                 "next": "state_s1_6_sex_health_lit_needs_important",
             },
             "state_s1_6_sex_health_lit_needs_important": {
-                "type": "choice",
+                "type": "list",
                 "text": "\n".join(
                     [
                         "*How true does this statement sound to you?*",
@@ -134,7 +153,7 @@ ASSESSMENT_QUESTIONS = {
                 "next": "state_s1_7_sex_health_lit_own_pleasure",
             },
             "state_s1_7_sex_health_lit_own_pleasure": {
-                "type": "choice",
+                "type": "list",
                 "text": "\n".join(
                     [
                         "*How true does this statement sound to you?*",
@@ -154,36 +173,42 @@ ASSESSMENT_QUESTIONS = {
             "state_s1_8_sex_health_lit_contraception_1": {
                 "text": "*During the last time you had sex, did you or your partner "
                 "do something or use any method to avoid or delay getting pregnant?*",
-                "type": "choice",
+                "type": "button",
                 "options": [
                     ("yes", "Yes"),
                     ("no", "No"),
                 ],
-                "next": "state_s1_9_sex_health_lit_contraceptive_2",
+                "next": {
+                    "yes": "state_s1_9_sex_health_lit_contraceptive_2",
+                    "no": "state_s1_progress_complete",
+                },
             },
             "state_s1_9_sex_health_lit_contraceptive_2": {
-                "type": "freetext",
+                "type": "choice",
                 "text": "\n".join(
                     [
                         "*What has been the main method that you or your partner "
                         "have used to delay or avoid getting pregnant?*",
                         "",
-                        "*1.* Pill",
-                        "*2.* Intra uterine device (IUD)",
-                        "*3.* Male condom",
-                        "*4.* Female condom",
-                        "*5.* Injectables",
-                        "*6.* Implants",
-                        "*7.* Diaphragm",
-                        "*8.* Foam/jelly",
-                        "*9.* Pulling out (withdrawal method)",
-                        "*10.* Lactational amenorrhea method",
-                        "*11.* Standard days method" "*12.* cyclebeads",
-                        "*13.* Female sterilisation",
-                        "*14.* Male sterilisation",
-                        "*15.* Exclusive breastfeeding",
                     ]
                 ),
+                "options": [
+                    ("pill", "Pill"),
+                    ("iud", "Intra uterine device (IUD)"),
+                    ("male_condom", "Male condom"),
+                    ("female_condom", "Female condom"),
+                    ("injectable", "Injectables"),
+                    ("implant", "Implants"),
+                    ("diaphragm", "Diaphragm"),
+                    ("foam_jelly", "Foam/jelly"),
+                    ("withdrawal", "Pulling out (withdrawal method)"),
+                    ("lactational_amenorrhea", "Lactational amenorrhea method"),
+                    ("standard_days", "Standard days method"),
+                    ("cyclebeads", "Cyclebeads"),
+                    ("female_sterilisation", "Female sterilisation"),
+                    ("male_sterilisation", "Male sterilisation"),
+                    ("exclusive_breastfeeding", "Exclusive breastfeeding"),
+                ],
                 "next": "state_s1_progress_complete",
             },
             "state_s1_progress_complete": {

--- a/yal/assessments.py
+++ b/yal/assessments.py
@@ -8,7 +8,7 @@ from vaccine.states import (
     WhatsAppButtonState,
     WhatsAppListState,
 )
-from yal.data.seqmentation_survey_questions import SURVEY_QUESTIONS
+from yal.assessment_data.sexual_health_literacy import ASSESSMENT_QUESTIONS
 from yal.utils import get_generic_error
 
 
@@ -18,24 +18,23 @@ class Application(BaseApplication):
     async def state_survey_question(self):
         metadata = self.user.metadata
 
-        section = str(metadata.get("segment_section", "1"))
-        print("state_survey_question", section, SURVEY_QUESTIONS.keys())
+        section = str(metadata.get("assessment_section", "1"))
 
-        if section not in SURVEY_QUESTIONS:
-            self.delete_metadata("segment_section")
-            self.delete_metadata("segment_question")
-            self.delete_metadata("segment_question_nr")
+        if section not in ASSESSMENT_QUESTIONS:
+            self.delete_metadata("assessment_section")
+            self.delete_metadata("assessment_question")
+            self.delete_metadata("assessment_question_nr")
             return await self.go_to_state(metadata["assessment_end_state"])
 
-        current_question = metadata.get("segment_question")
+        current_question = metadata.get("assessment_question")
 
         if not current_question:
-            current_question = SURVEY_QUESTIONS[section]["start"]
-            self.save_metadata("segment_question", current_question)
+            current_question = ASSESSMENT_QUESTIONS[section]["start"]
+            self.save_metadata("assessment_question", current_question)
 
-        question_number = metadata.get("segment_question_nr", 1)
+        question_number = metadata.get("assessment_question_nr", 1)
 
-        questions = SURVEY_QUESTIONS[section]["questions"]
+        questions = ASSESSMENT_QUESTIONS[section]["questions"]
         total_questions = sum(1 for q in questions.values() if q.get("type") != "info")
         progress_bar = (
             (question_number - 1) * "✅"
@@ -109,12 +108,12 @@ class Application(BaseApplication):
         metadata = self.user.metadata
         answers = self.user.answers
 
-        section = metadata.get("segment_section", 1)
-        current_question = metadata.get("segment_question")
+        section = metadata.get("assessment_section", 1)
+        current_question = metadata.get("assessment_question")
         answer = answers.get(current_question)
-        question_number = metadata.get("segment_question_nr", 1)
+        question_number = metadata.get("assessment_question_nr", 1)
 
-        question = SURVEY_QUESTIONS[str(section)]["questions"][current_question]
+        question = ASSESSMENT_QUESTIONS[str(section)]["questions"][current_question]
 
         next = None
 
@@ -125,11 +124,11 @@ class Application(BaseApplication):
                 next = question["next"]
 
         if next:
-            self.save_metadata("segment_question", next)
-            self.save_metadata("segment_question_nr", question_number + 1)
+            self.save_metadata("assessment_question", next)
+            self.save_metadata("assessment_question_nr", question_number + 1)
         else:
-            self.save_metadata("segment_section", section + 1)
-            self.save_metadata("segment_question_nr", 1)
-            self.delete_metadata("segment_question")
+            self.save_metadata("assessment_section", section + 1)
+            self.save_metadata("assessment_question_nr", 1)
+            self.delete_metadata("assessment_question")
 
         return await self.go_to_state("state_survey_question")

--- a/yal/change_preferences.py
+++ b/yal/change_preferences.py
@@ -540,7 +540,6 @@ class Application(BaseApplication):
 
         data = {
             "gender": self.user.answers.get("state_update_gender"),
-            "gender_other": self.user.answers.get("state_update_other_gender", ""),
         }
 
         error = await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)

--- a/yal/data/seqmentation_survey_questions.py
+++ b/yal/data/seqmentation_survey_questions.py
@@ -1,336 +1,64 @@
 SURVEY_QUESTIONS = {
     "1": {
-        "start": "state_s1_1_gender",
+        "start": "state_s1_1_sex_health_lit_sti",
         "questions": {
-            "state_s1_1_gender": {
-                "text": "*What gender do you identity with?*",
-                "options": [
-                    ("female", "Female"),
-                    ("male", "Male"),
-                    ("non_binary", "Non-binary"),
-                    ("trans", "Transgender"),
-                    ("self_describe", "Self-describe"),
-                    ("prefer_not_disclose", "Prefer not to disclose"),
-                ],
-                "next": {
-                    "female": "state_s1_3_age",
-                    "male": "state_s1_2_sex_with_men",
-                    "non_binary": "state_s1_2_sex_with_men",
-                    "trans": "state_s1_2_sex_with_men",
-                    "self_describe": "state_s1_2_sex_with_men",
-                    "prefer_not_disclose": "state_s1_2_sex_with_men",
-                },
-            },
-            "state_s1_2_sex_with_men": {
-                "text": "*Do you sometimes, or have you previously had sex with men?*",
-                "options": ["Yes", "No"],
-                "next": "state_s1_3_age",
-            },
-            "state_s1_3_age": {
-                "text": "*How old are you?*\n\n_Reply with your age e.g. 23_",
-                "type": "freetext",
-                "next": "state_s1_4_income",
-            },
-            "state_s1_4_income": {
-                "text": "*How much does everyone in your house make altogether, before "
-                "paying for regular monthly items?*",
-                "options": [
-                    ("no_income", "No income"),
-                    ("R1-R400", "R1 - R400"),
-                    ("R401-R800", "R401 - R800"),
-                    ("R801-R1600", "R801 - R1 600"),
-                    ("R1601-R3200", "R1 601 - R3 200"),
-                    ("R3201-R6400", "R3 201 - R6 400"),
-                    ("R6401-R12800", "R6 401 - R12 800"),
-                    ("R12801-R25600", "R12 801 - R25 600"),
-                    ("R25601-R51200", "R25 601 - R51 200"),
-                    ("R51201-R102400", "R51 201 - R102 400"),
-                    ("R102401-R204800", "R102 401 - R204 800"),
-                    ("R204801+", "R204 801 or more"),
-                ],
-                "next": "state_s1_5_relationship_status",
-            },
-            "state_s1_5_relationship_status": {
-                "text": "*What is your present relationship status?*",
-                "options": [
-                    ("no", "Not currently dating"),
-                    ("serious", "In a serious relationship"),
-                    ("not_serious", "In a relationship, but not a serious one"),
-                ],
-                "next": "state_s1_6_monthly_sex_partners",
-            },
-            "state_s1_6_monthly_sex_partners": {
-                "text": "*How many sexual partners did you have over the last month?*",
-                "options": [
-                    ("1-2", "One - two"),
-                    ("2-3", "Two - three"),
-                    ("other", "Other"),
-                    ("skip", "Skip"),
-                ],
-                "next": {
-                    "1-2": "state_s1_7_condom",
-                    "2-3": "state_s1_7_condom",
-                    "other": "state_s1_6_detail_monthly_sex_partners",
-                    "skip": "state_s1_7_condom",
-                },
-            },
-            "state_s1_6_detail_monthly_sex_partners": {
+            "state_s1_1_sex_health_lit_sti": {
                 "type": "freetext",
                 "text": "\n".join(
                     [
-                        "*Ok. You can tell me how many sexual partners you had here.*",
+                        "*_People can reduce the risk of getting STIs by:_*",
                         "",
-                        "_Just type and send_",
+                        "[persona_emoji] _Reply with the *number* "
+                        "of your chosen answer:_",
+                        "",
+                        "*1.* using to condoms every time they "
+                        "have sexual intercourse.",
+                        "",
+                        "*2.* only having sex with one partner who "
+                        "isn't infected and who has no other partners.",
                     ]
                 ),
-                "next": "state_s1_7_condom",
+                "next": "state_s1_2_sex_health_lit_consent",
             },
-            "state_s1_7_condom": {
-                "text": "*Did you use a condom last time you had penetrative sex?*",
-                "options": ["Yes", "No", "Skip"],
-                "next": "state_s1_8_sti_tested",
-            },
-            "state_s1_8_sti_tested": {
-                "text": "*Have you ever been tested for STIs and HIV?*",
-                "options": [("yes", "Yes"), ("no", "No")],
-                "next": {
-                    "yes": "state_s1_9_detail_sti_tested",
-                    "no": "state_sti_tested_skip_msg",
-                },
-            },
-            "state_sti_tested_skip_msg": {
-                "type": "info",
-                "text": "Please note, because you've selected NO, we're skipping some "
-                "questions as they don't apply to you.",
-                "next": "state_s1_12_5_partners_stis",
-            },
-            "state_s1_9_detail_sti_tested": {
-                "text": "*What STIs have you been tested for?*",
-                "options": [
-                    ("reply_with_sti", "Reply with STI"),
-                    ("skip", "Skip"),
-                ],
-                "next": {
-                    "reply_with_sti": "state_s1_9_detail_sti_name",
-                    "skip": "state_s1_10_tested_positive",
-                },
-            },
-            "state_s1_9_detail_sti_name": {
+            "state_s1_2_sex_health_lit_consent": {
                 "type": "freetext",
                 "text": "\n".join(
                     [
-                        "*Ok. You can tell me STI you were tested for here.*",
+                        "*If Teddy goes out to a restaurant and starts chatting "
+                        "with someone he is sexually attracted to, what is most "
+                        "appropriate way Teddy can tell that person wants to "
+                        "have sex with him?*",
                         "",
-                        "_Just type and send_",
+                        "[persona_emoji] _Reply with the *number* "
+                        "of your chosen answer:_",
+                        "",
+                        "*1*. By the way they are looking at him",
+                        "*2*. By what they are wearing",
+                        "*3*. If they carry condoms",
+                        "*4*. If Teddy has had sex with them before",
+                        "*5*. If they verbally consent to have sex",
+                        "*6*. I don't know",
                     ]
                 ),
-                "next": "state_s1_10_tested_positive",
+                "next": "state_s1_3_sex_health_lit_right_to_sex",
             },
-            "state_s1_10_tested_positive": {
-                "text": "*Were you diagnosed with an STI in the past?*",
-                "options": ["Yes", "No", "Skip"],
-                "next": "state_s1_11_hiv_status",
-            },
-            "state_s1_11_hiv_status": {
-                "text": "*Are you HIV positive?*",
-                "options": [("yes", "Yes"), ("no", "No"), ("skip", "Skip")],
-                "next": {
-                    "yes": "state_s1_12_hiv_medication",
-                    "no": "state_s1_12_5_partners_stis",
-                    "skip": "state_s1_12_5_partners_stis",
-                },
-            },
-            "state_s1_12_hiv_medication": {
-                "text": "Do you take your medication (PREP or ART) on a regular basis?",
-                "options": [("yes", "Yes"), ("no", "No")],
-                "next": "state_s1_12_5_partners_stis",
-            },
-            "state_s1_12_5_partners_stis": {
-                "text": "*Do you know if any of your sexual partners have had an STI?*",
-                "options": ["Yes", "No", "Skip"],
-                "next": "state_s1_13_addition_1_cut_down",
-            },
-            "state_s1_13_addition_1_cut_down": {
-                "text": "*Have you ever felt you needed to cut down on your drinking "
-                "or drug use?*",
-                "options": [("yes", "Yes"), ("no", "No")],
-                "next": "state_s1_14_addition_2_criticise",
-            },
-            "state_s1_14_addition_2_criticise": {
-                "text": "*Have people annoyed you by criticising your drinking or drug "
-                "use?*",
-                "options": [("yes", "Yes"), ("no", "No")],
-                "next": "state_s1_15_addition_3_guilt",
-            },
-            "state_s1_15_addition_3_guilt": {
-                "text": "*Have you ever felt guilty about drinking or drug use?*",
-                "options": [("yes", "Yes"), ("no", "No")],
-                "next": "state_s1_16_addition_4_morning",
-            },
-            "state_s1_16_addition_4_morning": {
-                "text": "*Have you ever felt you needed a drink or used drugs first "
-                "thing in the morning (eye‐opener) to steady your nerves or to get rid "
-                "of a hangover?*",
-                "options": [("yes", "Yes"), ("no", "No")],
-                "next": "state_s1_17_sexuality",
-            },
-            "state_s1_17_sexuality": {
-                "text": "*What is your sexual orientation?*",
-                "options": [
-                    ("straight", "Straight"),
-                    ("gay_or_lesbian", "Gay or Lesbian"),
-                    ("bisexual", "Bisexual"),
-                    ("queer", "Queer"),
-                    ("asexual", "Asexual"),
-                    ("self_describe", "Prefer to self-describe"),
-                    ("not_say", "Prefer not to say"),
-                ],
-                "next": "state_s1_18_disability_1_vision",
-            },
-            "state_s1_18_disability_1_vision": {
-                "text": "*Do you have difficulty seeing, even if wearing glasses?*",
-                "options": [
-                    ("no", "No difficulty"),
-                    ("some", "Some difficulty"),
-                    ("alot", "A lot of difficulty"),
-                    ("cannot_at_all", "Cannot do at all"),
-                ],
-                "next": "state_s1_19_disability_2_hearing",
-            },
-            "state_s1_19_disability_2_hearing": {
-                "text": "*Do you have difficulty hearing, even if using a hearing "
-                "aid(s)?*",
-                "options": [
-                    ("no", "No difficulty"),
-                    ("some", "Some difficulty"),
-                    ("alot", "A lot of difficulty"),
-                    ("cannot_at_all", "Cannot do at all"),
-                ],
-                "next": "state_s1_20_disability_3_walking",
-            },
-            "state_s1_20_disability_3_walking": {
-                "text": "*Do you have difficulty walking or climbing steps?*",
-                "options": [
-                    ("no", "No difficulty"),
-                    ("some", "Some difficulty"),
-                    ("alot", "A lot of difficulty"),
-                    ("cannot_at_all", "Cannot do at all"),
-                ],
-                "next": "state_s1_21_disability_4_concentrate",
-            },
-            "state_s1_21_disability_4_concentrate": {
-                "text": "*Do you have difficulty remembering or concentrating?*",
-                "options": [
-                    ("no", "No difficulty"),
-                    ("some", "Some difficulty"),
-                    ("alot", "A lot of difficulty"),
-                    ("cannot_at_all", "Cannot do at all"),
-                ],
-                "next": "state_s1_22_disability_5_selfcare",
-            },
-            "state_s1_22_disability_5_selfcare": {
-                "text": "*Do you have difficulty taking care of yourself, like washing "
-                "all over or getting dressing?*",
-                "options": [
-                    ("no", "No difficulty"),
-                    ("some", "Some difficulty"),
-                    ("alot", "A lot of difficulty"),
-                    ("cannot_at_all", "Cannot do at all"),
-                ],
-                "next": "state_s1_23_disability_6_communicate",
-            },
-            "state_s1_23_disability_6_communicate": {
-                "text": "*Do you have difficulty communicating in your home language, "
-                "like being understood or understanding others for example?*",
-                "options": [
-                    ("no", "No difficulty"),
-                    ("some", "Some difficulty"),
-                    ("alot", "A lot of difficulty"),
-                    ("cannot_at_all", "Cannot do at all"),
-                ],
-                "next": "state_s1_progress_complete",
-            },
-            "state_s1_progress_complete": {
-                "type": "info",
+            "state_s1_3_sex_health_lit_right_to_sex": {
+                "type": "choice",
                 "text": "\n".join(
                     [
-                        "😎 *YOU'RE DOING REALLY WELL.*",
+                        "*Robert and Samantha have been dating for 5 years and love "
+                        "each other very much.*",
                         "",
-                        "Section 1 complete, your airtime is getting closer. *Let's "
-                        "move onto section 2!* ➡️",
-                    ]
-                ),
-                "next": None,
-            },
-        },
-    },
-    "2": {
-        "start": "state_s2_1_knowledge_1_condoms",
-        "questions": {
-            "state_s2_1_knowledge_1_condoms": {
-                "text": "\n".join(
-                    [
-                        "_Do you think this is True or False?_",
-                        "",
-                        "*People can reduce the risk of getting STIs by using condoms "
-                        "every time they have sexual intercourse.*",
-                    ]
-                ),
-                "options": ["True", "False"],
-                "next": "state_s2_2_knowledge_2_exclusivity",
-            },
-            "state_s2_2_knowledge_2_exclusivity": {
-                "text": "\n".join(
-                    [
-                        "_Do you think this is True or False?_",
-                        "",
-                        "*People can reduce the risk of getting STIs by limiting "
-                        "sexual intercourse to one partner who is not infected and "
-                        "has no other partners.*",
-                    ]
-                ),
-                "options": ["True", "False"],
-                "next": "state_s2_3_knowledge_3_condoms_exclusivity",
-            },
-            "state_s2_3_knowledge_3_condoms_exclusivity": {
-                "text": "\n".join(
-                    [
-                        "_Do you think this is True or False?_",
-                        "",
-                        "*People can reduce the risk of getting STIs by using condoms "
-                        "every time they have sexual intercourse and by limiting "
-                        "sexual intercourse to one partner who is not infected and "
-                        "has no other partners.*",
-                    ]
-                ),
-                "options": ["True", "False"],
-                "next": "state_s2_4_competence_1_consent",
-            },
-            "state_s2_4_competence_1_consent": {
-                "text": "If Teddy goes out to a restaurant and starts a conversation "
-                "with someone he is sexually attracted to, *what is most important "
-                "way that Teddy can decide if the person he is talking to wants to "
-                "have sex with him?*",
-                "options": [
-                    ("look", "By the way they are looking at him"),
-                    ("clothes", "By what they are wearing"),
-                    ("carry_condoms", "If they carry condoms"),
-                    ("previous_sex", "If Teddy has had sex with them before"),
-                    ("verbal_consent", "If they verbally consent to have sex"),
-                    ("dont_know", "I don't know"),
-                ],
-                "next": "state_s2_5_competence_2_right_to_sex",
-            },
-            "state_s2_5_competence_2_right_to_sex": {
-                "text": "\n".join(
-                    [
-                        "Robert and Samantha have been dating for 5 years and love "
-                        "each other very much. Every year on Robert's birthday, "
+                        "Every year on Robert's birthday, "
                         "Samantha promises him sex for his birthday. This year, "
                         "Samantha tells Robert that she is too tired for sex.",
                         "",
-                        "To what extent do you agree with this statement: *Robert has "
-                        "the right to force Samantha to have sex.*",
+                        "*_How much do you agree or disagree with this statement?_* 👇🏾",
+                        "",
+                        "Robert has the right to force Samantha to have sex.",
+                        "",
+                        "_*Tap the button* below and select the option "
+                        "that describes how you feel._",
                     ]
                 ),
                 "options": [
@@ -340,15 +68,17 @@ SURVEY_QUESTIONS = {
                     ("disagree", "Disagree"),
                     ("strongly_disagree", "Strongly disagree"),
                 ],
-                "next": "state_s2_6_competence_3_insist_condoms",
+                "next": "state_s1_4_sex_health_lit_insist_condoms",
             },
-            "state_s2_6_competence_3_insist_condoms": {
+            "state_s1_4_sex_health_lit_insist_condoms": {
+                "type": "choice",
                 "text": "\n".join(
                     [
-                        "How much do you agree with the following statement:",
+                        "How much do you agree or disagree with "
+                        "the following statement:",
                         "",
-                        "*If sexually active, I am able to insist on condom use when "
-                        "I have sex.*",
+                        "If sexually active, I _am_ able to insist on condoms when "
+                        "I have sex.",
                     ]
                 ),
                 "options": [
@@ -359,661 +89,114 @@ SURVEY_QUESTIONS = {
                     ("strongly_disagree", "Strongly disagree"),
                     ("not_active", "I am not sexually active"),
                 ],
-                "next": "state_s2_7_competence_4_saying_no",
+                "next": "state_s1_5_sex_health_lit_saying_no",
             },
-            "state_s2_7_competence_4_saying_no": {
-                "text": "*If you are in a relationship, which statement describes you "
-                "best?*",
-                "options": [
-                    (
-                        "comfortable",
-                        "I feel comfortable telling my partner no if they want to "
-                        "have sex, but I do not want to",
-                    ),
-                    (
-                        "difficult",
-                        "I find it difficult to tell my partner 'no' if they want to "
-                        "have sex but I do not want to",
-                    ),
-                    ("not_sure", "I am not sure"),
-                    ("not_in_relationship", "Not in a relationship"),
-                ],
-                "next": "state_s2_8_enjoyment_1_needs_important",
+            "state_s1_5_sex_health_lit_saying_no": {
+                "type": "freetext",
+                "text": "\n".join(
+                    [
+                        "*If you are in a relationship, which statement describes you "
+                        "best?*",
+                        "",
+                        "[persona_emoji] _Reply with the *number* "
+                        "of your chosen answer:_",
+                        "",
+                        "*1.* I'm cool with telling bae no if they want "
+                        "to have sex but I don't.",
+                        "*2.* I find it hard to say no to bae if bae wants "
+                        "to have sex but I don't.",
+                        "*3.* I'm not sure how I feel about saying no when "
+                        "bae wants to have sex and I don't.",
+                        "*4.* I'm not in a relationship",
+                    ]
+                ),
+                "next": "state_s1_6_sex_health_lit_needs_important",
             },
-            "state_s2_8_enjoyment_1_needs_important": {
-                "text": "*My sexual needs or desires are important.*",
-                "options": [
-                    ("not", "Not at all true"),
-                    ("little", "A little true"),
-                    ("moderately", "Moderately true"),
-                    ("very", "Very true"),
-                    ("extremely", "Extremely true"),
-                ],
-                "next": "state_s2_9_enjoyment_2_own_pleasure",
-            },
-            "state_s2_9_enjoyment_2_own_pleasure": {
-                "text": "*I think it would be important to focus on my own pleasure "
-                "as well as my partner's during sexual experiences.*",
-                "options": [
-                    ("not", "Not at all true"),
-                    ("little", "A little true"),
-                    ("moderately", "Moderately true"),
-                    ("very", "Very true"),
-                    ("extremely", "Extremely true"),
-                ],
-                "next": "state_s2_10_enjoyment_3_expect_enjoy",
-            },
-            "state_s2_10_enjoyment_3_expect_enjoy": {
-                "text": "*I expect to enjoy sex*",
+            "state_s1_6_sex_health_lit_needs_important": {
+                "type": "choice",
+                "text": "\n".join(
+                    [
+                        "*How true does this statement sound to you?*",
+                        "",
+                        "My sexual needs or desires are important.",
+                        "",
+                        "[persona_emoji] _*Tap the button* below and "
+                        "select the option that describes how you feel_",
+                    ]
+                ),
                 "options": [
                     ("not", "Not at all true"),
                     ("little", "A little true"),
-                    ("moderately", "Moderately true"),
+                    ("moderately", "Kind of true"),
                     ("very", "Very true"),
                     ("extremely", "Extremely true"),
                 ],
-                "next": "state_s2_11_contraceptive_1_use",
+                "next": "state_s1_7_sex_health_lit_own_pleasure",
             },
-            "state_s2_11_contraceptive_1_use": {
+            "state_s1_7_sex_health_lit_own_pleasure": {
+                "type": "choice",
+                "text": "\n".join(
+                    [
+                        "*How true does this statement sound to you?*",
+                        "",
+                        "I expect to enjoy sex.",
+                    ]
+                ),
+                "options": [
+                    ("not", "Not at all true"),
+                    ("little", "A little true"),
+                    ("moderately", "Kind of true"),
+                    ("very", "Very true"),
+                    ("extremely", "Extremely true"),
+                ],
+                "next": "state_s1_8_sex_health_lit_contraception_1",
+            },
+            "state_s1_8_sex_health_lit_contraception_1": {
                 "text": "*During the last time you had sex, did you or your partner "
                 "do something or use any method to avoid or delay getting pregnant?*",
+                "type": "choice",
                 "options": [
                     ("yes", "Yes"),
                     ("no", "No"),
-                    ("dont_remember", "Don’t remember"),
-                    ("havent_had_sex", "I haven't had sex"),
                 ],
-                "next": "state_s2_12_contraceptive_2_detail",
+                "next": "state_s1_9_sex_health_lit_contraceptive_2",
             },
-            "state_s2_12_contraceptive_2_detail": {
-                "text": "*What has been the main method that you or your partner "
-                "have used to delay or avoid getting pregnant?*",
-                "options": [
-                    ("none", "None"),
-                    ("pill", "Pill"),
-                    ("iud", "Intra uterine device (IUD)"),
-                    ("male_condom", "Male condom"),
-                    ("female_condom", "Female condom"),
-                    ("inject", "Injectables"),
-                    ("implant", "Implants"),
-                    ("diaphragm", "Diaphragm"),
-                    ("foam_jelly", "Foam/jelly"),
-                    ("lactational", "Lactational amenorrhea method"),
-                    ("cyclebeads", "Standard days method / cyclebeads"),
-                    ("female_sterilisation", "Female sterilisation"),
-                    ("male_sterilisation", "Male sterilisation"),
-                    ("breastfeeding", "Exclusive breastfeeding"),
-                    ("havent_had_sex", "I haven't had sex"),
-                ],
-                "next": "state_s2_progress_complete",
+            "state_s1_9_sex_health_lit_contraceptive_2": {
+                "type": "freetext",
+                "text": "\n".join(
+                    [
+                        "*What has been the main method that you or your partner "
+                        "have used to delay or avoid getting pregnant?*",
+                        "",
+                        "*1.* Pill",
+                        "*2.* Intra uterine device (IUD)",
+                        "*3.* Male condom",
+                        "*4.* Female condom",
+                        "*5.* Injectables",
+                        "*6.* Implants",
+                        "*7.* Diaphragm",
+                        "*8.* Foam/jelly",
+                        "*9.* Pulling out (withdrawal method)",
+                        "*10.* Lactational amenorrhea method",
+                        "*11.* Standard days method" "*12.* cyclebeads",
+                        "*13.* Female sterilisation",
+                        "*14.* Male sterilisation",
+                        "*15.* Exclusive breastfeeding",
+                    ]
+                ),
+                "next": "state_s1_progress_complete",
             },
-            "state_s2_progress_complete": {
+            "state_s1_progress_complete": {
                 "type": "info",
                 "text": "\n".join(
                     [
-                        "😎 *CONGRATS. YOU'RE HALFWAY THERE!*",
+                        "🏁 🎉",
                         "",
-                        "Section 2 complete, keep going. *Let's move onto section 3!* "
-                        "👍🏾",
+                        "Awesome. That's all the questions for now!",
+                        "",
+                        "🤦🏾‍♂️ Thanks for being so patient and honest 😌.",
                     ]
                 ),
-                "next": None,
-            },
-        },
-    },
-    "3": {
-        "start": "state_s3_1_loc_1_boss",
-        "questions": {
-            "state_s3_1_loc_1_boss": {
-                "text": "\n".join(
-                    [
-                        "_The following statements may apply more or less to you. To "
-                        "what extent do you think each statement applies to you "
-                        "personally?_",
-                        "",
-                        "*I’m my own boss.*",
-                    ]
-                ),
-                "options": [
-                    "Does not apply at all",
-                    "Applies somewhat",
-                    "Applies",
-                    "Applies a lot",
-                    "Applies completely",
-                ],
-                "next": "state_s3_2_loc_2_work",
-            },
-            "state_s3_2_loc_2_work": {
-                "text": "\n".join(
-                    [
-                        "_The following statements may apply more or less to you. To "
-                        "what extent do you think each statement applies to you "
-                        "personally?_",
-                        "",
-                        "*If I work hard, I will success.*",
-                    ]
-                ),
-                "options": [
-                    "Does not apply at all",
-                    "Applies somewhat",
-                    "Applies",
-                    "Applies a lot",
-                    "Applies completely",
-                ],
-                "next": "state_s3_3_loc_3_others",
-            },
-            "state_s3_3_loc_3_others": {
-                "text": "\n".join(
-                    [
-                        "_The following statements may apply more or less to you. To "
-                        "what extent do you think each statement applies to you "
-                        "personally?_",
-                        "",
-                        "*What I do is mainly determined by others.*",
-                    ]
-                ),
-                "options": [
-                    "Does not apply at all",
-                    "Applies somewhat",
-                    "Applies",
-                    "Applies a lot",
-                    "Applies completely",
-                ],
-                "next": "state_s3_4_loc_4_fate",
-            },
-            "state_s3_4_loc_4_fate": {
-                "text": "\n".join(
-                    [
-                        "_The following statements may apply more or less to you. To "
-                        "what extent do you think each statement applies to you "
-                        "personally?_",
-                        "",
-                        "*Fate often gets in the way of my plans.*",
-                    ]
-                ),
-                "options": [
-                    "Does not apply at all",
-                    "Applies somewhat",
-                    "Applies",
-                    "Applies a lot",
-                    "Applies completely",
-                ],
-                "next": "state_s3_5_spch_doing",
-            },
-            "state_s3_5_spch_doing": {
-                "text": "*How good a job do you feel you are doing in taking care of "
-                "your health?*",
-                "options": [
-                    "Excellent",
-                    "Very Good",
-                    "Good",
-                    "Fair",
-                    "Poor",
-                ],
-                "next": "state_s3_6_spch_clinic",
-            },
-            "state_s3_6_spch_clinic": {
-                "text": "*When I have a health need (e.g. contraception, flu "
-                "symptoms), I go to my closest clinic.*",
-                "options": [
-                    "Yes",
-                    "No",
-                    "Sometimes",
-                ],
-                "next": "state_s3_7_selfesteem_1_qualities",
-            },
-            "state_s3_7_selfesteem_1_qualities": {
-                "text": "*I feel that I am a person of worth, at least on an equal "
-                "plane with others.*",
-                "options": [
-                    "Strongly agree",
-                    "Agree",
-                    "Disagree",
-                    "Strongly disagree",
-                ],
-                "next": "state_s3_8_selfesteem_2_worth",
-            },
-            "state_s3_8_selfesteem_2_worth": {
-                "text": "*I feel that I am a person of worth, at least on an equal "
-                "plane with others.*",
-                "options": [
-                    "Strongly agree",
-                    "Agree",
-                    "Disagree",
-                    "Strongly disagree",
-                ],
-                "next": "state_s3_9_selfesteem_3_failure",
-            },
-            "state_s3_9_selfesteem_3_failure": {
-                "text": "*All in all, I am inclined to feel that I am a failure.*",
-                "options": [
-                    "Strongly agree",
-                    "Agree",
-                    "Disagree",
-                    "Strongly disagree",
-                ],
-                "next": "state_s3_10_selfesteem_4_capable",
-            },
-            "state_s3_10_selfesteem_4_capable": {
-                "text": "*I am able to do things as well as most other people.*",
-                "options": [
-                    "Strongly agree",
-                    "Agree",
-                    "Disagree",
-                    "Strongly disagree",
-                ],
-                "next": "state_s3_11_selfesteem_5_proud",
-            },
-            "state_s3_11_selfesteem_5_proud": {
-                "text": "*I feel I do not have much to be proud of.*",
-                "options": [
-                    "Strongly agree",
-                    "Agree",
-                    "Disagree",
-                    "Strongly disagree",
-                ],
-                "next": "state_s3_12_selfesteem_6_positive",
-            },
-            "state_s3_12_selfesteem_6_positive": {
-                "text": "*I take a positive attitude toward myself.*",
-                "options": [
-                    "Strongly agree",
-                    "Agree",
-                    "Disagree",
-                    "Strongly disagree",
-                ],
-                "next": "state_s3_13_self_esteem_7_satisfied",
-            },
-            "state_s3_13_self_esteem_7_satisfied": {
-                "text": "*On the whole, I am satisfied with myself.*",
-                "options": [
-                    "Strongly agree",
-                    "Agree",
-                    "Disagree",
-                    "Strongly disagree",
-                ],
-                "next": "state_s3_14_selfesteem_8_respect",
-            },
-            "state_s3_14_selfesteem_8_respect": {
-                "text": "*I wish I could have more respect for myself.*",
-                "options": [
-                    "Strongly agree",
-                    "Agree",
-                    "Disagree",
-                    "Strongly disagree",
-                ],
-                "next": "state_s3_15_selfesteem_9_nogood",
-            },
-            "state_s3_15_selfesteem_9_nogood": {
-                "text": "*At times I think I am no good at all.*",
-                "options": [
-                    "Strongly agree",
-                    "Agree",
-                    "Disagree",
-                    "Strongly disagree",
-                ],
-                "next": "state_s3_16_selfesteem_10_useless",
-            },
-            "state_s3_16_selfesteem_10_useless": {
-                "text": "*I certainly feel useless at times.*",
-                "options": [
-                    "Strongly agree",
-                    "Agree",
-                    "Disagree",
-                    "Strongly disagree",
-                ],
-                "next": "state_s3_17_resilience_1_believe",
-            },
-            "state_s3_17_resilience_1_believe": {
-                "text": "\n".join(
-                    [
-                        "_Do you agree with the following statements?_",
-                        "",
-                        "*I believe in myself*",
-                    ]
-                ),
-                "options": [
-                    "Not at all",
-                    "A little",
-                    "Somewhat",
-                    "Quite a bit",
-                    "A lot",
-                ],
-                "next": "state_s3_18_resilience_2_adapt",
-            },
-            "state_s3_18_resilience_2_adapt": {
-                "text": "\n".join(
-                    [
-                        "_Do you agree with the following statements?_",
-                        "",
-                        "*I can adapt to challenging situations*",
-                    ]
-                ),
-                "options": [
-                    "Not at all",
-                    "A little",
-                    "Somewhat",
-                    "Quite a bit",
-                    "A lot",
-                ],
-                "next": "state_s3_19_resilience_3_solutions",
-            },
-            "state_s3_19_resilience_3_solutions": {
-                "text": "\n".join(
-                    [
-                        "_Do you agree with the following statements?_",
-                        "",
-                        "*I find solutions to problems I encounter*",
-                    ]
-                ),
-                "options": [
-                    "Not at all",
-                    "A little",
-                    "Somewhat",
-                    "Quite a bit",
-                    "A lot",
-                ],
-                "next": "state_s3_20_resilience_4_difficulties",
-            },
-            "state_s3_20_resilience_4_difficulties": {
-                "text": "\n".join(
-                    [
-                        "_Do you agree with the following statements?_",
-                        "",
-                        "*I can keep going despite difficulties*",
-                    ]
-                ),
-                "options": [
-                    "Not at all",
-                    "A little",
-                    "Somewhat",
-                    "Quite a bit",
-                    "A lot",
-                ],
-                "next": "state_s3_21_resilience_5_cope",
-            },
-            "state_s3_21_resilience_5_cope": {
-                "text": "\n".join(
-                    [
-                        "_Do you agree with the following statements?_",
-                        "",
-                        "*I can cope with competing demands (for my time or "
-                        "attention)*",
-                    ]
-                ),
-                "options": [
-                    "Not at all",
-                    "A little",
-                    "Somewhat",
-                    "Quite a bit",
-                    "A lot",
-                ],
-                "next": "state_s3_22_resilience_6_hope",
-            },
-            "state_s3_22_resilience_6_hope": {
-                "text": "\n".join(
-                    [
-                        "_Do you agree with the following statements?_",
-                        "",
-                        "*Even when there are setbacks or obstacles, I am hopeful "
-                        "about my future*",
-                    ]
-                ),
-                "options": [
-                    "Not at all",
-                    "A little",
-                    "Somewhat",
-                    "Quite a bit",
-                    "A lot",
-                ],
-                "next": "state_s3_23_resilience_7_emotions",
-            },
-            "state_s3_23_resilience_7_emotions": {
-                "text": "\n".join(
-                    [
-                        "_Do you agree with the following statements?_",
-                        "",
-                        "*I am generally in control of my emotions*",
-                    ]
-                ),
-                "options": [
-                    "Not at all",
-                    "A little",
-                    "Somewhat",
-                    "Quite a bit",
-                    "A lot",
-                ],
-                "next": "state_s3_24_resilience_8_pride",
-            },
-            "state_s3_24_resilience_8_pride": {
-                "text": "\n".join(
-                    [
-                        "_Do you agree with the following statements?_",
-                        "",
-                        "*I take pride in things I have achieved*",
-                    ]
-                ),
-                "options": [
-                    "Not at all",
-                    "A little",
-                    "Somewhat",
-                    "Quite a bit",
-                    "A lot",
-                ],
-                "next": "state_s3_25_resilience_9_rise",
-            },
-            "state_s3_25_resilience_9_rise": {
-                "text": "\n".join(
-                    [
-                        "_Do you agree with the following statements?_",
-                        "",
-                        "*When faced with difficulties, I rise to the challenge*",
-                    ]
-                ),
-                "options": [
-                    "Not at all",
-                    "A little",
-                    "Somewhat",
-                    "Quite a bit",
-                    "A lot",
-                ],
-                "next": "state_s3_26_resilience_10_meaning",
-            },
-            "state_s3_26_resilience_10_meaning": {
-                "text": "\n".join(
-                    [
-                        "_Do you agree with the following statements?_",
-                        "",
-                        "*I can find meaning in my life*",
-                    ]
-                ),
-                "options": [
-                    "Not at all",
-                    "A little",
-                    "Somewhat",
-                    "Quite a bit",
-                    "A lot",
-                ],
-                "next": "state_s3_27_gen_att_1_beating",
-            },
-            "state_s3_27_gen_att_1_beating": {
-                "text": "\n".join(
-                    [
-                        "_How do you feel about each statement? There are no right or "
-                        "wrong answers._",
-                        "",
-                        "*There are times when a woman deserves to be beaten*",
-                    ]
-                ),
-                "options": [
-                    "Strongly agree",
-                    "Somewhat agree",
-                    "Do not agree",
-                ],
-                "next": "state_s3_28_gen_att_2_pregnant",
-            },
-            "state_s3_28_gen_att_2_pregnant": {
-                "text": "\n".join(
-                    [
-                        "_How do you feel about each statement? There are no right or "
-                        "wrong answers._",
-                        "",
-                        "*It’s a woman’s responsibility to avoid getting pregnant*",
-                    ]
-                ),
-                "options": [
-                    "Strongly agree",
-                    "Somewhat agree",
-                    "Do not agree",
-                ],
-                "next": "state_s3_29_gen_att_3_contraception",
-            },
-            "state_s3_29_gen_att_3_contraception": {
-                "text": "\n".join(
-                    [
-                        "_How do you feel about each statement? There are no right or "
-                        "wrong answers._",
-                        "",
-                        "*A man and a woman should decide together what type of "
-                        "contraceptive to use*",
-                    ]
-                ),
-                "options": [
-                    "Strongly agree",
-                    "Somewhat agree",
-                    "Do not agree",
-                ],
-                "next": "state_s3_30_gen_att_4_parenting",
-            },
-            "state_s3_30_gen_att_4_parenting": {
-                "text": "\n".join(
-                    [
-                        "_How do you feel about each statement? There are no right or "
-                        "wrong answers._",
-                        "",
-                        "*If a guy gets women pregnant, the child is both of their "
-                        "responsibility*",
-                    ]
-                ),
-                "options": [
-                    "Strongly agree",
-                    "Somewhat agree",
-                    "Do not agree",
-                ],
-                "next": "state_s3_progress_complete",
-            },
-            "state_s3_progress_complete": {
-                "type": "info",
-                "text": "\n".join(
-                    [
-                        "🤩 *SHO! That was a long one but guess what, YOU'RE ALMOST "
-                        "DONE!*",
-                        "",
-                        "Section 3 complete. *Just one more section* to go and your "
-                        "airtime will be in you phone.📲",
-                    ]
-                ),
-                "next": None,
-            },
-        },
-    },
-    "4": {
-        "start": "state_s4_start",
-        "questions": {
-            "state_s4_start": {
-                "type": "info",
-                "text": "\n".join(
-                    [
-                        "*BWise / Survey*",
-                        "*-----*",
-                        "",
-                        "Over the last two weeks, how often have you been bothered by "
-                        "the following problems?",
-                    ]
-                ),
-                "next": "state_s4_1_depression_1_anxious",
-            },
-            "state_s4_1_depression_1_anxious": {
-                "text": "*Feeling nervous, anxious or on edge*",
-                "options": [
-                    "Not at all",
-                    "Several days",
-                    "More than half the days",
-                    "Nearly every day",
-                ],
-                "next": "state_s4_2_depression_2_worrying",
-            },
-            "state_s4_2_depression_2_worrying": {
-                "text": "*Not being able to stop or control worrying*",
-                "options": [
-                    "Not at all",
-                    "Several days",
-                    "More than half the days",
-                    "Nearly every day",
-                ],
-                "next": "state_s4_3_depression_3_hopeless",
-            },
-            "state_s4_3_depression_3_hopeless": {
-                "text": "*Feeling down, depressed or hopeless*",
-                "options": [
-                    "Not at all",
-                    "Several days",
-                    "More than half the days",
-                    "Nearly every day",
-                ],
-                "next": "state_s4_4_depression_4_interest",
-            },
-            "state_s4_4_depression_4_interest": {
-                "text": "*Little interest or pleasure in doing things*",
-                "options": [
-                    "Not at all",
-                    "Several days",
-                    "More than half the days",
-                    "Nearly every day",
-                ],
-                "next": "state_s4_5_connectedness",
-            },
-            "state_s4_5_connectedness": {
-                "text": "*Do you have someone to talk to when you have a worry or "
-                "problem?*",
-                "options": [
-                    "Never",
-                    "Some of the time",
-                    "Most of the time",
-                    "All the time",
-                ],
-                "next": "state_s4_6_self_concept_1_myself",
-            },
-            "state_s4_6_self_concept_1_myself": {
-                "text": "\n".join(
-                    [
-                        "_How do you feel about this statement?_",
-                        "",
-                        "*I feel good about myself*",
-                    ]
-                ),
-                "options": [
-                    "Never",
-                    "Some of the time",
-                    "Most of the time",
-                    "All the time",
-                ],
-                "next": "state_s4_7_self_concept_2_body",
-            },
-            "state_s4_7_self_concept_2_body": {
-                "text": "\n".join(
-                    [
-                        "_How do you feel about this statement?_",
-                        "",
-                        "*I feel good about my body*",
-                    ]
-                ),
-                "options": [
-                    "Never",
-                    "Some of the time",
-                    "Most of the time",
-                    "All the time",
-                ],
                 "next": None,
             },
         },

--- a/yal/main.py
+++ b/yal/main.py
@@ -5,6 +5,7 @@ from vaccine.states import EndState
 from vaccine.utils import random_id
 from yal import rapidpro, utils
 from yal.askaquestion import Application as AaqApplication
+from yal.assessments import Application as SegmentationSurveyApplication
 from yal.change_preferences import Application as ChangePreferencesApplication
 from yal.content_feedback_survey import ContentFeedbackSurveyApplication
 from yal.mainmenu import Application as MainMenuApplication
@@ -13,7 +14,6 @@ from yal.optout import Application as OptOutApplication
 from yal.pleasecallme import Application as PleaseCallMeApplication
 from yal.pushmessages_optin import Application as PushMessageOptInApplication
 from yal.quiz import Application as QuizApplication
-from yal.segmentation_survey import Application as SegmentationSurveyApplication
 from yal.servicefinder import Application as ServiceFinderApplication
 from yal.servicefinder_feedback_survey import ServiceFinderFeedbackSurveyApplication
 from yal.terms_and_conditions import Application as TermsApplication

--- a/yal/main.py
+++ b/yal/main.py
@@ -12,6 +12,7 @@ from yal.onboarding import Application as OnboardingApplication
 from yal.optout import Application as OptOutApplication
 from yal.pleasecallme import Application as PleaseCallMeApplication
 from yal.quiz import Application as QuizApplication
+from yal.segmentation_survey import Application as SegmentationSurveyApplication
 from yal.servicefinder import Application as ServiceFinderApplication
 from yal.servicefinder_feedback_survey import ServiceFinderFeedbackSurveyApplication
 from yal.terms_and_conditions import Application as TermsApplication
@@ -63,6 +64,7 @@ class Application(
     ContentFeedbackSurveyApplication,
     WaFbCrossoverFeedbackApplication,
     ServiceFinderFeedbackSurveyApplication,
+    SegmentationSurveyApplication,
 ):
     START_STATE = "state_start"
 

--- a/yal/onboarding.py
+++ b/yal/onboarding.py
@@ -10,7 +10,7 @@ from vaccine.states import (
     WhatsAppListState,
 )
 from yal import rapidpro, utils
-from yal.segmentation_survey import Application as SegmentationSurveyApplication
+from yal.assessments import Application as SegmentationSurveyApplication
 from yal.utils import get_current_datetime, get_generic_error
 from yal.validators import age_validator
 

--- a/yal/onboarding.py
+++ b/yal/onboarding.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 
 from vaccine.base_application import BaseApplication
-from vaccine.states import Choice, FreeText, WhatsAppListState
+from vaccine.states import Choice, FreeText, WhatsAppButtonState, WhatsAppListState
 from yal import rapidpro, utils
 from yal.segmentation_survey import Application as SegmentationSurveyApplication
 from yal.utils import get_current_datetime, get_generic_error
@@ -231,7 +231,41 @@ class Application(BaseApplication):
         )
 
         await self.publish_message(msg)
-        return await self.go_to_state(SegmentationSurveyApplication.START_STATE)
+        return await self.go_to_state("state_sexual_literacy_assessment_start")
+
+    async def state_sexual_literacy_assessment_start(self):
+        msg = self._(
+            "\n".join(
+                [
+                    "*You and your sexual health*",
+                    "-----",
+                    "",
+                    "[persona_emoji] I've got a tonne of answers and info about sex, "
+                    "love and relationships.",
+                    "",
+                    "To point you in the right direction, "
+                    "I want to quickly check what you already know.",
+                ]
+            )
+        )
+        await self.publish_message(msg)
+        await asyncio.sleep(0.5)
+        question = self._(
+            "\n".join(
+                [
+                    "I'll ask a few questions. For each question "
+                    "I just need you to choose the answer that feels right to you."
+                ]
+            )
+        )
+
+        return WhatsAppButtonState(
+            app=self,
+            question=question,
+            choices=[Choice("ok", "OK, let's start!")],
+            error=get_generic_error(),
+            next=SegmentationSurveyApplication.START_STATE,
+        )
 
     async def state_stop_onboarding_reminders(self):
         msisdn = utils.normalise_phonenumber(self.inbound.from_addr)

--- a/yal/onboarding.py
+++ b/yal/onboarding.py
@@ -149,7 +149,7 @@ class Application(BaseApplication):
                     "ABOUT YOU / 🌈 *Your identity*",
                     "-----",
                     "",
-                    "*What's your gender?*",
+                    "*Which gender do you most identify with?*",
                     "",
                     "_Tap the button and select the option you think best fits._",
                 ]

--- a/yal/onboarding.py
+++ b/yal/onboarding.py
@@ -2,7 +2,13 @@ import asyncio
 import logging
 
 from vaccine.base_application import BaseApplication
-from vaccine.states import Choice, FreeText, WhatsAppButtonState, WhatsAppListState
+from vaccine.states import (
+    Choice,
+    EndState,
+    FreeText,
+    WhatsAppButtonState,
+    WhatsAppListState,
+)
 from yal import rapidpro, utils
 from yal.segmentation_survey import Application as SegmentationSurveyApplication
 from yal.utils import get_current_datetime, get_generic_error
@@ -259,6 +265,10 @@ class Application(BaseApplication):
             )
         )
 
+        self.save_metadata(
+            "assessment_end_state", "state_sexual_literacy_assessment_end"
+        )
+
         return WhatsAppButtonState(
             app=self,
             question=question,
@@ -266,6 +276,20 @@ class Application(BaseApplication):
             error=get_generic_error(),
             next=SegmentationSurveyApplication.START_STATE,
         )
+
+    async def state_sexual_literacy_assessment_end(self):
+        msg = "\n".join(
+            [
+                "🏁 🎉",
+                "",
+                "*Awesome. That's all the questions for now!*",
+                "",
+                "🤦🏾‍♂️ Thanks for being so patient and honest 😌.",
+            ]
+        )
+        return EndState(self, msg)
+
+        # TODO: Go down different path depending on assessment outcome
 
     async def state_stop_onboarding_reminders(self):
         msisdn = utils.normalise_phonenumber(self.inbound.from_addr)

--- a/yal/optout.py
+++ b/yal/optout.py
@@ -172,7 +172,6 @@ class Application(BaseApplication):
             "location_description": "",
             "persona_name": "",
             "persona_emoji": "",
-            "gender_other": "",
             "emergency_contact": "",
         } | self.reminders_to_be_cleared
         old_details = self.__get_user_details(self.user.metadata)

--- a/yal/pushmessages_optin.py
+++ b/yal/pushmessages_optin.py
@@ -49,7 +49,7 @@ class Application(BaseApplication):
         msisdn = normalise_phonenumber(self.inbound.from_addr)
         whatsapp_id = msisdn.lstrip(" + ")
         data = {
-            "opted_in": "False",
+            "push_message_opt_in": "False",
         }
         error = await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)
         if error:
@@ -75,7 +75,7 @@ class Application(BaseApplication):
         msisdn = normalise_phonenumber(self.inbound.from_addr)
         whatsapp_id = msisdn.lstrip(" + ")
         data = {
-            "opted_in": "True",
+            "push_message_opt_in": "True",
         }
         error = await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)
         if error:

--- a/yal/segmentation_survey.py
+++ b/yal/segmentation_survey.py
@@ -8,6 +8,7 @@ from vaccine.states import (
     EndState,
     FreeText,
     WhatsAppButtonState,
+    WhatsAppListState,
 )
 from yal import config, rapidpro, utils
 from yal.data.seqmentation_survey_questions import SURVEY_QUESTIONS
@@ -145,21 +146,31 @@ class Application(BaseApplication):
             ]
         )
 
-        if question_type == "choice":
-            choices = []
-            for option in question["options"]:
-                if isinstance(option, tuple):
-                    stub, option = option
-                else:
-                    stub = option.replace(" ", "_").lower()
-                choices.append(Choice(stub, option))
+        choices = []
+        for option in question.get("options", []):
+            if isinstance(option, tuple):
+                stub, option = option
+            else:
+                stub = option.replace(" ", "_").lower()
+            choices.append(Choice(stub, option))
 
+        if question_type == "choice":
             return ChoiceState(
                 self,
                 question=question["text"] + "\n",
                 header=header,
                 error=get_generic_error() + "\n",
                 choices=choices,
+                next="state_survey_process_answer",
+                override_answer_name=current_question,
+            )
+        elif question_type == "list":
+            return WhatsAppListState(
+                self,
+                question=f"{header}\n{question['text']}",
+                error=get_generic_error(),
+                choices=choices,
+                button=question.get("button", "Choose option"),
                 next="state_survey_process_answer",
                 override_answer_name=current_question,
             )

--- a/yal/segmentation_survey.py
+++ b/yal/segmentation_survey.py
@@ -72,21 +72,35 @@ class Application(BaseApplication):
         msg = self._(
             "\n".join(
                 [
-                    "*Awesome, let's get straight into it.*",
-                    "",
-                    "There are 4 sections to the survey. Each section should take "
-                    "around *5-10 min* to complete.",
-                    "",
+                    "*You and your sexual health*",
                     "-----",
-                    "*Or reply:*",
-                    BACK_TO_MAIN,
+                    "",
+                    "🤦🏾‍♂️I've got a ton of answers and info about sex, "
+                    "love and relationships.",
+                    "",
+                    "To point you in the right direction, "
+                    "I want to quickly check what you already know.",
                 ]
             )
         )
         await self.publish_message(msg)
         await asyncio.sleep(0.5)
+        question = self._(
+            "\n".join(
+                [
+                    "I'll ask a few questions. For each question "
+                    "I just need you to choose the answer that feels right to you."
+                ]
+            )
+        )
 
-        return await self.go_to_state("state_survey_question")
+        return WhatsAppButtonState(
+            app=self,
+            question=question,
+            choices=[Choice("ok", "OK, let's start!")],
+            error=get_generic_error(),
+            next="state_survey_question",
+        )
 
     async def state_survey_question(self):
         metadata = self.user.metadata
@@ -109,6 +123,11 @@ class Application(BaseApplication):
 
         questions = SURVEY_QUESTIONS[section]["questions"]
         total_questions = sum(1 for q in questions.values() if q.get("type") != "info")
+        progress_bar = (
+            (question_number - 1) * "✅"
+            + "◼️"
+            + (total_questions - question_number) * "◽️"
+        )
 
         question = questions[current_question]
         question_type = question.get("type", "choice")
@@ -120,20 +139,9 @@ class Application(BaseApplication):
 
         header = "\n".join(
             [
-                "*BWise / Survey*",
+                f"{progress_bar}",
                 "-----",
-                f"Section {section}",
-                f"{question_number}/{total_questions}",
                 "",
-            ]
-        )
-        footer = "\n".join(
-            [
-                "",
-                "-----",
-                "*Or reply:*",
-                BACK_TO_MAIN,
-                GET_HELP,
             ]
         )
 
@@ -150,9 +158,7 @@ class Application(BaseApplication):
                 self,
                 question=question["text"] + "\n",
                 header=header,
-                footer=footer,
                 error=get_generic_error() + "\n",
-                error_footer=footer,
                 choices=choices,
                 next="state_survey_process_answer",
                 override_answer_name=current_question,
@@ -162,7 +168,6 @@ class Application(BaseApplication):
                 self,
                 question=question["text"],
                 header=header,
-                footer=footer,
                 next="state_survey_process_answer",
                 override_answer_name=current_question,
             )

--- a/yal/segmentation_survey.py
+++ b/yal/segmentation_survey.py
@@ -75,7 +75,7 @@ class Application(BaseApplication):
                     "*You and your sexual health*",
                     "-----",
                     "",
-                    "🤦🏾‍♂️I've got a ton of answers and info about sex, "
+                    "[persona_emoji] I've got a tonne of answers and info about sex, "
                     "love and relationships.",
                     "",
                     "To point you in the right direction, "

--- a/yal/segmentation_survey.py
+++ b/yal/segmentation_survey.py
@@ -174,6 +174,15 @@ class Application(BaseApplication):
                 next="state_survey_process_answer",
                 override_answer_name=current_question,
             )
+        elif question_type == "button":
+            return WhatsAppButtonState(
+                self,
+                question=f"{header}\n{question['text']}",
+                error=get_generic_error(),
+                choices=choices,
+                next="state_survey_process_answer",
+                override_answer_name=current_question,
+            )
         else:
             return FreeText(
                 self,

--- a/yal/tests/states_dictionary.md
+++ b/yal/tests/states_dictionary.md
@@ -102,6 +102,7 @@
 | state_reschedule_onboarding_reminders      |        TRUE        |     Text     |            TRUE          | Sets onboarding reminder fields so that reminder is resent later                                              |
 | state_handle_onboarding_reminder_response  |        TRUE        |     Text     |            TRUE          | Routes user to other state based on their reponse to the onboarding reminder                              |
 state_rel_status                             |        TRUE        |     Text     |            TRUE          | Asks the user for their current relationship states, user response is "relationship", "single", "complicated"
+state_sexual_literacy_assessment_start       |        TRUE        |     Text     |            TRUE          | User responds "ok" when they start the assessment                                                                   |
 
 ### OptOut flow
 | state_name                                 | accepts_user_input |   data_type  | added_to_flow_results_app | description                                                                      |

--- a/yal/tests/states_dictionary.md
+++ b/yal/tests/states_dictionary.md
@@ -95,14 +95,13 @@
 | state_save_persona_emoji                   |        FALSE       |              |            FALSE         | Updates user profile with the new emoji                                                                        |
 | state_profile_intro                        |        FALSE       |              |            FALSE         | Sends a message to thank and set expectations                                                                 |
 | state_age                                  |        TRUE        |     Int      |            TRUE          | Asks user to enter their age                                                                                  |
-| state_gender                               |        TRUE        |     Text     |            TRUE          | Asks user to enter their gender. User response is "female", "male", "non_binary", "other" or "rather_not_say" |
-| state_other_gender                         |        TRUE        |     Text     |            TRUE          | Asks user to enter their gender using free text                                                               |
+| state_gender                               |        TRUE        |     Text     |            TRUE          | Asks user to enter their gender. User response is "female", "male", "non_binary", "none of these" or "rather_not_say" |
 | state_submit_onboarding                    |        FALSE       |     Text     |            TRUE          | Adds onboarding choices to user profile                                                                      |
 | state_onboarding_complete                  |        FALSE       |              |            TRUE          | Redirects user to AAQ start state in case they want to ask a question                                      |
 | state_stop_onboarding_reminders            |        TRUE        |     Text     |            TRUE          | Resets fields used for onboarding reminders                                                                 |
 | state_reschedule_onboarding_reminders      |        TRUE        |     Text     |            TRUE          | Sets onboarding reminder fields so that reminder is resent later                                              |
 | state_handle_onboarding_reminder_response  |        TRUE        |     Text     |            TRUE          | Routes user to other state based on their reponse to the onboarding reminder                              |
-
+state_rel_status                             |        TRUE        |     Text     |            TRUE          | Asks the user for their current relationship states, user response is "relationship", "single", "complicated"
 
 ### OptOut flow
 | state_name                                 | accepts_user_input |   data_type  | added_to_flow_results_app | description                                                                      |

--- a/yal/tests/states_dictionary.md
+++ b/yal/tests/states_dictionary.md
@@ -103,6 +103,7 @@
 | state_handle_onboarding_reminder_response  |        TRUE        |     Text     |            TRUE          | Routes user to other state based on their reponse to the onboarding reminder                              |
 state_rel_status                             |        TRUE        |     Text     |            TRUE          | Asks the user for their current relationship states, user response is "relationship", "single", "complicated"
 state_sexual_literacy_assessment_start       |        TRUE        |     Text     |            TRUE          | User responds "ok" when they start the assessment                                                                   |
+state_sexual_literacy_assessment_end         |        FALSE       |              |            FALSE         | User has completed the assessment and receives the end message
 
 ### OptOut flow
 | state_name                                 | accepts_user_input |   data_type  | added_to_flow_results_app | description                                                                      |

--- a/yal/tests/test_assessments.py
+++ b/yal/tests/test_assessments.py
@@ -65,7 +65,7 @@ async def test_survey_next_question(tester: AppTester):
     tester.setup_state("state_survey_question")
     await tester.user_input("2")
     tester.assert_state("state_survey_question")
-    tester.assert_answer("state_s1_1_sex_health_lit_sti", "2")
+    tester.assert_answer("state_s1_1_sex_health_lit_sti", "single_partner")
 
 
 @pytest.mark.asyncio

--- a/yal/tests/test_assessments.py
+++ b/yal/tests/test_assessments.py
@@ -61,13 +61,6 @@ async def rapidpro_mock():
 
 
 @pytest.mark.asyncio
-async def test_survey_start(tester: AppTester, rapidpro_mock):
-    tester.setup_state("state_sexual_literacy_assessment_start")
-    await tester.user_input("OK, let's start!")
-    tester.assert_state("state_survey_question")
-
-
-@pytest.mark.asyncio
 async def test_survey_next_question(tester: AppTester):
     tester.setup_state("state_survey_question")
     await tester.user_input("2")
@@ -97,7 +90,7 @@ async def test_list_question_type(tester: AppTester):
             },
         }
     }
-    with mock.patch("yal.segmentation_survey.SURVEY_QUESTIONS", questions):
+    with mock.patch("yal.assessments.ASSESSMENT_QUESTIONS", questions):
         tester.setup_state("state_survey_question")
         await tester.user_input(session=Message.SESSION_EVENT.NEW)
         tester.assert_message(
@@ -129,7 +122,7 @@ async def test_button_question_type(tester: AppTester):
             },
         }
     }
-    with mock.patch("yal.segmentation_survey.SURVEY_QUESTIONS", questions):
+    with mock.patch("yal.assessments.ASSESSMENT_QUESTIONS", questions):
         tester.setup_state("state_survey_question")
         await tester.user_input(session=Message.SESSION_EVENT.NEW)
         tester.assert_message(

--- a/yal/tests/test_change_preferences.py
+++ b/yal/tests/test_change_preferences.py
@@ -296,7 +296,6 @@ async def test_state_update_gender_confirm_not_correct(
 @pytest.mark.asyncio
 async def test_state_update_gender_submit(tester: AppTester, rapidpro_mock):
     tester.setup_answer("state_update_gender", "other")
-    tester.setup_answer("state_other_gender", "gender fluid")
     tester.setup_state("state_update_gender_confirm")
     await tester.user_input("1")
     tester.assert_num_messages(1)

--- a/yal/tests/test_main.py
+++ b/yal/tests/test_main.py
@@ -9,6 +9,7 @@ from vaccine.models import Message
 from vaccine.testing import AppTester, TState, run_sanic
 from yal import config
 from yal.askaquestion import Application as AaqApplication
+from yal.assessments import Application as SegmentSurveyApplication
 from yal.change_preferences import Application as ChangePreferencesApplication
 from yal.content_feedback_survey import ContentFeedbackSurveyApplication
 from yal.main import Application
@@ -17,7 +18,6 @@ from yal.onboarding import Application as OnboardingApplication
 from yal.optout import Application as OptoutApplication
 from yal.pleasecallme import Application as PleaseCallMeApplication
 from yal.quiz import Application as QuizApplication
-from yal.segmentation_survey import Application as SegmentSurveyApplication
 from yal.servicefinder import Application as ServiceFinderApplication
 from yal.servicefinder_feedback_survey import ServiceFinderFeedbackSurveyApplication
 from yal.terms_and_conditions import Application as TermsApplication

--- a/yal/tests/test_onboarding.py
+++ b/yal/tests/test_onboarding.py
@@ -290,7 +290,7 @@ async def test_submit_onboarding(tester: AppTester, rapidpro_mock):
         buttons=["OK, let's start!"],
     )
 
-    assert len(rapidpro_mock.tstate.requests) == 4
+    assert len(rapidpro_mock.tstate.requests) == 3
     request = rapidpro_mock.tstate.requests[2]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {

--- a/yal/tests/test_onboarding.py
+++ b/yal/tests/test_onboarding.py
@@ -417,7 +417,7 @@ async def test_assessment_complete(tester: AppTester, rapidpro_mock):
     tester.user.metadata[
         "assessment_end_state"
     ] = "state_sexual_literacy_assessment_end"
-    tester.user.metadata["segment_section"] = 2
+    tester.user.metadata["assessment_section"] = 2
     tester.setup_state("state_survey_question")
     await tester.user_input()
     tester.assert_message(

--- a/yal/tests/test_onboarding.py
+++ b/yal/tests/test_onboarding.py
@@ -225,7 +225,7 @@ async def test_state_gender(get_current_datetime, tester: AppTester, rapidpro_mo
                 "ABOUT YOU / 🌈 *Your identity*",
                 "-----",
                 "",
-                "*What's your gender?*",
+                "*Which gender do you most identify with?*",
                 "",
                 "_Tap the button and select the option you think best fits._",
             ]

--- a/yal/tests/test_onboarding.py
+++ b/yal/tests/test_onboarding.py
@@ -271,36 +271,26 @@ async def test_state_gender_from_list(
 
 @pytest.mark.asyncio
 async def test_submit_onboarding(tester: AppTester, rapidpro_mock):
-    tester.setup_state("state_start_survey")
+    tester.setup_state("state_rel_status")
     tester.setup_answer("state_age", "22")
     tester.setup_answer("state_gender", "other")
     tester.setup_answer("state_persona_name", "Nurse Joy")
     tester.setup_answer("state_persona_emoji", "⛑️")
-    tester.setup_answer("state_rel_status", "single")
 
-    await tester.user_input("OK, let's start!")
-    await tester.user_input("1")
-    await tester.user_input("2")
-    await tester.user_input("Strongly agree")
-    await tester.user_input("Strongly agree")
-    await tester.user_input("3")
-    await tester.user_input("Not at all true")
-    await tester.user_input("Not at all true")
-    await tester.user_input("Yes")
-    await tester.user_input("4")
+    await tester.user_input("No, I'm single")
+
     tester.assert_num_messages(1)
     tester.assert_message(
         "\n".join(
             [
-                "🙏🏾 Lekker! Your profile is all set up!",
-                "",
-                "Let's get you started!",
+                "I'll ask a few questions. For each question "
+                "I just need you to choose the answer that feels right to you."
             ]
         ),
-        buttons=["Main menu"],
+        buttons=["OK, let's start!"],
     )
 
-    assert len(rapidpro_mock.tstate.requests) == 3
+    assert len(rapidpro_mock.tstate.requests) == 4
     request = rapidpro_mock.tstate.requests[2]
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {

--- a/yal/tests/test_onboarding.py
+++ b/yal/tests/test_onboarding.py
@@ -400,3 +400,34 @@ async def test_onboarding_set_first_time_menu(
             "terms_accepted": "True",
         },
     }
+
+
+@pytest.mark.asyncio
+async def test_assessment_start(tester: AppTester, rapidpro_mock):
+    tester.setup_state("state_sexual_literacy_assessment_start")
+    await tester.user_input("OK, let's start!")
+    tester.assert_state("state_survey_question")
+    tester.assert_metadata(
+        "assessment_end_state", "state_sexual_literacy_assessment_end"
+    )
+
+
+@pytest.mark.asyncio
+async def test_assessment_complete(tester: AppTester, rapidpro_mock):
+    tester.user.metadata[
+        "assessment_end_state"
+    ] = "state_sexual_literacy_assessment_end"
+    tester.user.metadata["segment_section"] = 2
+    tester.setup_state("state_survey_question")
+    await tester.user_input()
+    tester.assert_message(
+        "\n".join(
+            [
+                "🏁 🎉",
+                "",
+                "*Awesome. That's all the questions for now!*",
+                "",
+                "🤦🏾‍♂️ Thanks for being so patient and honest 😌.",
+            ]
+        )
+    )

--- a/yal/tests/test_optout.py
+++ b/yal/tests/test_optout.py
@@ -56,7 +56,6 @@ def get_rapidpro_contact(urn):
             "latitude": "456",
             "persona_name": "Aslan",
             "persona_emoji": "🦁",
-            "gender_other": "non conforming",
             "emergency_contact": "123-emergency",
         }
     return contact
@@ -264,7 +263,6 @@ async def test_state_optout_delete_saved(
             "location_description": "",
             "persona_name": "",
             "persona_emoji": "",
-            "gender_other": "",
             "emergency_contact": "",
         },
     }

--- a/yal/tests/test_pushmessages_optin.py
+++ b/yal/tests/test_pushmessages_optin.py
@@ -82,7 +82,7 @@ async def test_state_pushmessages_optin(tester: AppTester, rapidpro_mock):
     assert len(rapidpro_mock.tstate.requests) == 2
     request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
-        "fields": {"push_message_opt_in ": "True"},
+        "fields": {"push_message_opt_in": "True"},
     }
 
 
@@ -95,5 +95,5 @@ async def test_state_pushmessages_optin_no(tester: AppTester, rapidpro_mock):
     assert len(rapidpro_mock.tstate.requests) == 2
     request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
-        "fields": {"push_message_opt_in ": "False"},
+        "fields": {"push_message_opt_in": "False"},
     }

--- a/yal/tests/test_pushmessages_optin.py
+++ b/yal/tests/test_pushmessages_optin.py
@@ -82,7 +82,7 @@ async def test_state_pushmessages_optin(tester: AppTester, rapidpro_mock):
     assert len(rapidpro_mock.tstate.requests) == 2
     request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
-        "fields": {"opted_in": "True"},
+        "fields": {"push_message_opt_in ": "True"},
     }
 
 
@@ -95,5 +95,5 @@ async def test_state_pushmessages_optin_no(tester: AppTester, rapidpro_mock):
     assert len(rapidpro_mock.tstate.requests) == 2
     request = rapidpro_mock.tstate.requests[1]
     assert json.loads(request.body.decode("utf-8")) == {
-        "fields": {"opted_in": "False"},
+        "fields": {"push_message_opt_in ": "False"},
     }

--- a/yal/tests/test_segmentation_survey.py
+++ b/yal/tests/test_segmentation_survey.py
@@ -1,13 +1,9 @@
-import json
-import random
-
 import pytest
 from sanic import Sanic, response
 
 from vaccine.models import Message
 from vaccine.testing import AppTester, TState, run_sanic
 from yal import config
-from yal.data.seqmentation_survey_questions import SURVEY_QUESTIONS
 from yal.segmentation_survey import Application
 
 
@@ -64,44 +60,28 @@ async def rapidpro_mock():
 
 @pytest.mark.asyncio
 async def test_survey_start(tester: AppTester, rapidpro_mock):
-    await tester.user_input("Hell Yeah!", session=Message.SESSION_EVENT.NEW)
-    tester.assert_state("state_survey_question")
+    tester.setup_state("state_start_survey")
+    await tester.user_input("OK, let's start!", session=Message.SESSION_EVENT.NEW)
 
     [msg] = tester.fake_worker.outbound_messages
     assert msg.content == "\n".join(
         [
-            "*Awesome, let's get straight into it.*",
-            "",
-            "There are 4 sections to the survey. Each section should take around *5-10 "
-            "min* to complete.",
-            "",
+            "*You and your sexual health*",
             "-----",
-            "*Or reply:*",
-            "0. 🏠 Back to Main *MENU*",
+            "",
+            "🤦🏾‍♂️I've got a ton of answers and info about sex, "
+            "love and relationships.",
+            "",
+            "To point you in the right direction, "
+            "I want to quickly check what you already know.",
         ]
     )
 
     tester.assert_message(
         "\n".join(
             [
-                "*BWise / Survey*",
-                "-----",
-                "Section 1",
-                "1/26",
-                "",
-                "*What gender do you identity with?*",
-                "",
-                "1. Female",
-                "2. Male",
-                "3. Non-binary",
-                "4. Transgender",
-                "5. Self-describe",
-                "6. Prefer not to disclose",
-                "",
-                "-----",
-                "*Or reply:*",
-                "0. 🏠 Back to Main *MENU*",
-                "#. 🆘Get *HELP*",
+                "I'll ask a few questions. For each question "
+                "I just need you to choose the answer that feels right to you."
             ]
         )
     )
@@ -112,30 +92,6 @@ async def test_survey_start(tester: AppTester, rapidpro_mock):
 
 
 @pytest.mark.asyncio
-async def test_survey_start_decline(tester: AppTester, rapidpro_mock):
-    await tester.user_input("No, rather not", session=Message.SESSION_EVENT.NEW)
-    tester.assert_state("state_survey_decline")
-
-    tester.assert_message(
-        "\n".join(
-            [
-                "*No problem and no pressure!* 😎",
-                "",
-                "What would you like to do next?",
-                "",
-                "1. Ask a question",
-                "2. Go to Main Menu",
-                "-----",
-                "*Or reply:*",
-                "0. 🏠 Back to Main *MENU*",
-            ]
-        )
-    )
-
-    assert rapidpro_mock.tstate.contact_fields["segment_survey_complete"] == "decline"
-
-
-@pytest.mark.asyncio
 async def test_survey_next_question(tester: AppTester):
     tester.setup_state("state_survey_question")
     await tester.user_input("2")
@@ -143,254 +99,23 @@ async def test_survey_next_question(tester: AppTester):
     tester.assert_message(
         "\n".join(
             [
-                "*BWise / Survey*",
+                "✅◼️◽️◽️◽️◽️◽️◽️◽️",
                 "-----",
-                "Section 1",
-                "2/26",
                 "",
-                "*Do you sometimes, or have you previously had sex with men?*",
+                "*If Teddy goes out to a restaurant and starts chatting "
+                "with someone he is sexually attracted to, what is most "
+                "appropriate way Teddy can tell that person wants to "
+                "have sex with him?*",
                 "",
-                "1. Yes",
-                "2. No",
+                "[persona_emoji] _Reply with the *number* " "of your chosen answer:_",
                 "",
-                "-----",
-                "*Or reply:*",
-                "0. 🏠 Back to Main *MENU*",
-                "#. 🆘Get *HELP*",
+                "*1*. By the way they are looking at him",
+                "*2*. By what they are wearing",
+                "*3*. If they carry condoms",
+                "*4*. If Teddy has had sex with them before",
+                "*5*. If they verbally consent to have sex",
+                "*6*. I don't know",
             ]
         )
     )
-    tester.assert_answer("state_s1_1_gender", "male")
-
-
-@pytest.mark.asyncio
-async def test_survey_invalid_answer(tester: AppTester):
-    random.seed(0)
-
-    tester.setup_state("state_survey_question")
-    await tester.user_input("A")
-    tester.assert_state("state_survey_question")
-    tester.assert_message(
-        "\n".join(
-            [
-                "Oops, looks like I don't have that option available.🤔Please try "
-                "again - I'll get it if you use the number that matches your choice, "
-                "promise.👍",
-                "",
-                "1. Female",
-                "2. Male",
-                "3. Non-binary",
-                "4. Transgender",
-                "5. Self-describe",
-                "6. Prefer not to disclose",
-                "",
-                "-----",
-                "*Or reply:*",
-                "0. 🏠 Back to Main *MENU*",
-                "#. 🆘Get *HELP*",
-            ]
-        )
-    )
-    tester.assert_no_answer("state_s1_4_income")
-
-
-@pytest.mark.asyncio
-async def test_survey_next_question_branch(tester: AppTester):
-    tester.user.metadata["segment_question"] = "state_s1_6_monthly_sex_partners"
-    tester.setup_state("state_survey_question")
-    await tester.user_input("3")
-    tester.assert_state("state_survey_question")
-    tester.assert_message(
-        "\n".join(
-            [
-                "*BWise / Survey*",
-                "-----",
-                "Section 1",
-                "2/26",
-                "",
-                "*Ok. You can tell me how many sexual partners you had here.*",
-                "",
-                "_Just type and send_",
-                "",
-                "-----",
-                "*Or reply:*",
-                "0. 🏠 Back to Main *MENU*",
-                "#. 🆘Get *HELP*",
-            ]
-        )
-    )
-
-
-@pytest.mark.asyncio
-async def test_survey_freetext_question(tester: AppTester):
-    tester.user.metadata["segment_section"] = 1
-    tester.user.metadata["segment_question"] = "state_s1_6_detail_monthly_sex_partners"
-
-    tester.setup_state("state_survey_question")
-    await tester.user_input(session=Message.SESSION_EVENT.NEW)
-
-    tester.assert_message(
-        "\n".join(
-            [
-                "*BWise / Survey*",
-                "-----",
-                "Section 1",
-                "1/26",
-                "",
-                "*Ok. You can tell me how many sexual partners you had here.*",
-                "",
-                "_Just type and send_",
-                "",
-                "-----",
-                "*Or reply:*",
-                "0. 🏠 Back to Main *MENU*",
-                "#. 🆘Get *HELP*",
-            ]
-        )
-    )
-
-    await tester.user_input("11")
-
-    tester.assert_state("state_survey_question")
-
-    tester.assert_answer("state_s1_6_detail_monthly_sex_partners", "11")
-
-
-@pytest.mark.asyncio
-async def test_survey_info_message(tester: AppTester):
-    tester.user.metadata["segment_section"] = 1
-    tester.user.metadata["segment_question"] = "state_s1_8_sti_tested"
-
-    tester.setup_state("state_survey_question")
-    await tester.user_input("no")
-    tester.assert_state("state_survey_question")
-
-    [msg] = tester.fake_worker.outbound_messages
-    assert msg.content == (
-        "Please note, because you've selected NO, we're skipping some questions as "
-        "they don't apply to you."
-    )
-
-    tester.assert_metadata("segment_question", "state_s1_12_5_partners_stis")
-
-
-@pytest.mark.asyncio
-async def test_survey_next_section(tester: AppTester):
-    tester.user.metadata["segment_section"] = 2
-    tester.user.metadata["segment_question"] = "state_s2_12_contraceptive_2_detail"
-
-    tester.setup_state("state_survey_question")
-    await tester.user_input("1")
-    tester.assert_state("state_survey_question")
-
-    tester.assert_message(
-        "\n".join(
-            [
-                "*BWise / Survey*",
-                "-----",
-                "Section 3",
-                "1/30",
-                "",
-                "_The following statements may apply more or less to you. To what "
-                "extent do you think each statement applies to you personally?_",
-                "",
-                "*I’m my own boss.*",
-                "",
-                "1. Does not apply at all",
-                "2. Applies somewhat",
-                "3. Applies",
-                "4. Applies a lot",
-                "5. Applies completely",
-                "",
-                "-----",
-                "*Or reply:*",
-                "0. 🏠 Back to Main *MENU*",
-                "#. 🆘Get *HELP*",
-            ]
-        )
-    )
-
-    [msg] = tester.fake_worker.outbound_messages
-    assert msg.content == "\n".join(
-        [
-            "😎 *CONGRATS. YOU'RE HALFWAY THERE!*",
-            "",
-            "Section 2 complete, keep going. *Let's move onto section 3!* 👍🏾",
-        ]
-    )
-
-
-@pytest.mark.asyncio
-async def test_survey_end(tester: AppTester):
-    tester.user.metadata["segment_section"] = 4
-    tester.user.metadata["segment_question"] = "state_s4_7_self_concept_2_body"
-
-    tester.setup_state("state_survey_question")
-    await tester.user_input("1")
-    tester.assert_state("state_survey_done")
-
-    # Make sure metadata was cleaned up and survey can be repeated
-    tester.setup_state("state_start_survey")
-    await tester.user_input("1")
-    tester.assert_state("state_survey_question")
-
-
-@pytest.mark.asyncio
-async def test_survey_start_to_end():
-    def get_next(section, current_question):
-        if not current_question:
-            return
-
-        assert (
-            current_question in SURVEY_QUESTIONS[section]["questions"]
-        ), f"Section {section} - broken link to: {current_question}"
-
-        question = SURVEY_QUESTIONS[section]["questions"][current_question]
-
-        paths = []
-        if type(question.get("next")) == dict:
-            paths = set(question["next"].values())
-        else:
-            paths.append(question.get("next"))
-
-        return all([get_next(section, path) for path in paths])
-
-    for section in SURVEY_QUESTIONS.keys():
-        get_next(section, SURVEY_QUESTIONS[section]["start"])
-
-
-@pytest.mark.asyncio
-async def test_state_survey_done(tester: AppTester, rapidpro_mock):
-    tester.setup_state("state_survey_done")
-    await tester.user_input("Get Airtime")
-    tester.assert_state("state_prompt_next_action")
-
-    tester.assert_message(
-        "\n".join(
-            [
-                "*BWise / Survey*",
-                "-----",
-                "",
-                "We've just sent you your airtime. Please check your airtime balance "
-                "now.",
-                "",
-                "*What would you like to do next?*",
-                "",
-                "1. Ask a question",
-                "2. Go to Main Menu",
-                "3. I didn't receive airtime",
-                "",
-                "-----",
-                "*Or reply:*",
-                "*0* - 🏠Back to Main *MENU*",
-                "*#* - 🆘Get *HELP*",
-            ]
-        )
-    )
-
-    assert len(rapidpro_mock.tstate.requests) == 1
-    request = rapidpro_mock.tstate.requests[0]
-    assert json.loads(request.body.decode("utf-8")) == {
-        "flow": "segment-airtime-flow-uuid",
-        "urns": ["whatsapp:27820001001"],
-    }
+    tester.assert_answer("state_s1_1_sex_health_lit_sti", "2")

--- a/yal/tests/test_segmentation_survey.py
+++ b/yal/tests/test_segmentation_survey.py
@@ -78,7 +78,11 @@ async def test_survey_next_question(tester: AppTester):
 
 
 @pytest.mark.asyncio
-async def test_list_message_type(tester: AppTester):
+async def test_list_question_type(tester: AppTester):
+    """
+    The list question type should ask the user the question using a whatsapp list
+    interactive message
+    """
     questions = {
         "1": {
             "start": "q1",
@@ -102,4 +106,35 @@ async def test_list_message_type(tester: AppTester):
             content="\n".join(["◼️", "-----", "", "Test question"]),
             list_items=["Choice 1", "Choice 2"],
             button="Select a choice",
+        )
+
+
+@pytest.mark.asyncio
+async def test_button_question_type(tester: AppTester):
+    """
+    The list question type should ask the user the question using a whatsapp button
+    interactive message
+    """
+    questions = {
+        "1": {
+            "start": "q1",
+            "questions": {
+                "q1": {
+                    "type": "button",
+                    "text": "Test question",
+                    "options": [
+                        "Choice 1",
+                        "Choice 2",
+                    ],
+                    "button": "Select a choice",
+                }
+            },
+        }
+    }
+    with mock.patch("yal.segmentation_survey.SURVEY_QUESTIONS", questions):
+        tester.setup_state("state_survey_question")
+        await tester.user_input(session=Message.SESSION_EVENT.NEW)
+        tester.assert_message(
+            content="\n".join(["◼️", "-----", "", "Test question"]),
+            buttons=["Choice 1", "Choice 2"],
         )

--- a/yal/tests/test_segmentation_survey.py
+++ b/yal/tests/test_segmentation_survey.py
@@ -62,30 +62,6 @@ async def rapidpro_mock():
 async def test_survey_start(tester: AppTester, rapidpro_mock):
     tester.setup_state("state_start_survey")
     await tester.user_input("OK, let's start!", session=Message.SESSION_EVENT.NEW)
-
-    [msg] = tester.fake_worker.outbound_messages
-    assert msg.content == "\n".join(
-        [
-            "*You and your sexual health*",
-            "-----",
-            "",
-            "🤦🏾‍♂️I've got a ton of answers and info about sex, "
-            "love and relationships.",
-            "",
-            "To point you in the right direction, "
-            "I want to quickly check what you already know.",
-        ]
-    )
-
-    tester.assert_message(
-        "\n".join(
-            [
-                "I'll ask a few questions. For each question "
-                "I just need you to choose the answer that feels right to you."
-            ]
-        )
-    )
-
     assert (
         rapidpro_mock.tstate.contact_fields["segment_survey_complete"] == "inprogress"
     )
@@ -96,26 +72,4 @@ async def test_survey_next_question(tester: AppTester):
     tester.setup_state("state_survey_question")
     await tester.user_input("2")
     tester.assert_state("state_survey_question")
-    tester.assert_message(
-        "\n".join(
-            [
-                "✅◼️◽️◽️◽️◽️◽️◽️◽️",
-                "-----",
-                "",
-                "*If Teddy goes out to a restaurant and starts chatting "
-                "with someone he is sexually attracted to, what is most "
-                "appropriate way Teddy can tell that person wants to "
-                "have sex with him?*",
-                "",
-                "[persona_emoji] _Reply with the *number* " "of your chosen answer:_",
-                "",
-                "*1*. By the way they are looking at him",
-                "*2*. By what they are wearing",
-                "*3*. If they carry condoms",
-                "*4*. If Teddy has had sex with them before",
-                "*5*. If they verbally consent to have sex",
-                "*6*. I don't know",
-            ]
-        )
-    )
     tester.assert_answer("state_s1_1_sex_health_lit_sti", "2")

--- a/yal/tests/test_segmentation_survey.py
+++ b/yal/tests/test_segmentation_survey.py
@@ -6,7 +6,7 @@ from sanic import Sanic, response
 from vaccine.models import Message
 from vaccine.testing import AppTester, TState, run_sanic
 from yal import config
-from yal.segmentation_survey import Application
+from yal.main import Application
 
 
 @pytest.fixture
@@ -62,11 +62,9 @@ async def rapidpro_mock():
 
 @pytest.mark.asyncio
 async def test_survey_start(tester: AppTester, rapidpro_mock):
-    tester.setup_state("state_start_survey")
-    await tester.user_input("OK, let's start!", session=Message.SESSION_EVENT.NEW)
-    assert (
-        rapidpro_mock.tstate.contact_fields["segment_survey_complete"] == "inprogress"
-    )
+    tester.setup_state("state_sexual_literacy_assessment_start")
+    await tester.user_input("OK, let's start!")
+    tester.assert_state("state_survey_question")
 
 
 @pytest.mark.asyncio

--- a/yal/tests/test_segmentation_survey.py
+++ b/yal/tests/test_segmentation_survey.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 from sanic import Sanic, response
 
@@ -73,3 +75,31 @@ async def test_survey_next_question(tester: AppTester):
     await tester.user_input("2")
     tester.assert_state("state_survey_question")
     tester.assert_answer("state_s1_1_sex_health_lit_sti", "2")
+
+
+@pytest.mark.asyncio
+async def test_list_message_type(tester: AppTester):
+    questions = {
+        "1": {
+            "start": "q1",
+            "questions": {
+                "q1": {
+                    "type": "list",
+                    "text": "Test question",
+                    "options": [
+                        "Choice 1",
+                        "Choice 2",
+                    ],
+                    "button": "Select a choice",
+                }
+            },
+        }
+    }
+    with mock.patch("yal.segmentation_survey.SURVEY_QUESTIONS", questions):
+        tester.setup_state("state_survey_question")
+        await tester.user_input(session=Message.SESSION_EVENT.NEW)
+        tester.assert_message(
+            content="\n".join(["◼️", "-----", "", "Test question"]),
+            list_items=["Choice 1", "Choice 2"],
+            button="Select a choice",
+        )


### PR DESCRIPTION
Notes: 
- the new onboarding is simplified and "gender_other" is removed 
- relationship status has been added to onboarding 
- onboarding goes straight to the first assessment, onboarding is submitted just before it goes to the assessments 

Tasks:
- [x] Add new question types for whatsapp list and button messages
- [x] Use the same generic assessment flow for multiple assessments
- [ ] Add triggers + surrounding flows for each of the assessments (they're not just assessments, there's things surrounding the assessment that need to be hardcoded in)
- [ ]  Add scoring
- [x] states for opt in for push messages 
- [x] remove tests for assessments that contain content
- [ ] go back over miroboard to ensure all changes to content are caught
- [ ] add all requested contact fields from DS 
- [ ] reminders
