### PR TITLE
Assessment questions in data dictionary

### DIFF
--- a/yal/assessment_data/A1_sexual_health_literacy.py
+++ b/yal/assessment_data/A1_sexual_health_literacy.py
@@ -64,7 +64,7 @@ ASSESSMENT_QUESTIONS = {
                 "next": "state_a1_q3_sexual_health_lit_info",
             },
             "state_a1_q3_sexual_health_lit_info": {
-                "type": "list",
+                "type": "info",
                 "text": "\n".join(
                     [
                         "_*Robert and Samantha have been dating for 5 years and love "

--- a/yal/scripts/compare_docs_to_flow_results.py
+++ b/yal/scripts/compare_docs_to_flow_results.py
@@ -1,0 +1,64 @@
+import argparse
+import asyncio
+from urllib.parse import urljoin
+
+import aiohttp
+import pytablereader
+
+
+def get_arguments():
+    parser = argparse.ArgumentParser(
+        description="Compares the documentation to the flow results specification on "
+        "the server, and notifies on any questions missing on the server"
+    )
+    parser.add_argument("url", help="The base URL for the flow results server")
+    parser.add_argument(
+        "token", help="An authorization token to access the flow results server"
+    )
+    return parser.parse_args()
+
+
+def get_documented_states():
+    loader = pytablereader.MarkdownTableFileLoader("yal/tests/states_dictionary.md")
+    documented_states = set()
+    for data in loader.load():
+        documented_states = documented_states | set(
+            row["state_name"]
+            for row in data.as_dict()[data.table_name]
+            if row["accepts_user_input"]
+        )
+    return documented_states
+
+
+async def get_server_states(args: argparse.Namespace):
+    packages_url = urljoin(args.url, "api/v1/flow-results/packages/")
+    headers = {
+        "Authorization": f"Token {args.token}",
+        "Accept": "application/json",
+        "User-Agent": "compare-docs-script",
+    }
+    async with aiohttp.ClientSession() as session:
+        async with session.get(packages_url, headers=headers) as resp:
+            flow_id = (await resp.json())["data"][0]["id"]
+        package_url = urljoin(packages_url, f"{flow_id}/")
+        async with session.get(package_url, headers=headers) as resp:
+            return set(
+                (await resp.json())["data"]["attributes"]["resources"][0]["schema"][
+                    "questions"
+                ].keys()
+            )
+
+
+def main():
+    args = get_arguments()
+    documented_states = get_documented_states()
+    server_states = asyncio.run(get_server_states(args))
+    difference = documented_states - server_states
+    assert (
+        len(difference) == 0
+    ), f"{len(difference)} states are not in the definition. List: {difference}"
+    print("Done! No missing questions found")
+
+
+if __name__ == "__main__":
+    main()

--- a/yal/tests/states_dictionary.md
+++ b/yal/tests/states_dictionary.md
@@ -360,3 +360,16 @@ state_sexual_literacy_assessment_end         |        FALSE       |             
 | ---------- | ------------------ | --------- | ----------- |
 | state_a2_2_q5_healthcare | TRUE | Text | When I have health needs (like  contraception or flu symptoms), I go to my closest clinic. |
 | state_a2_2_q6_healthcare | TRUE | Text | How good a job do you feel you are doing in taking care of your health? |
+
+### A8 Self esteem
+| state_name | accepts_user_input | data_type | description |
+| ---------- | ------------------ | --------- | ----------- |
+| state_a2_3_q1_self_esteem | TRUE | Text | I feel that I am a person who has worth — at least as much worth as others. |
+| state_a2_3_q2_self_esteem | TRUE | Text | I feel like I have quite a few of good qualities. |
+| state_a2_3_q3_self_esteem | TRUE | Text | In general, I tend to feel like a failure. |
+| state_a2_3_q4_self_esteem | TRUE | Text | I feel like I don't have much to be proud of. |
+| state_a2_3_q5_self_esteem | TRUE | Text | I have a positive attitude toward myself. |
+| state_a2_3_q6_self_esteem | TRUE | Text | I'm generally satisfied with myself. |
+| state_a2_3_q7_self_esteem | TRUE | Text | I wish I could have more respect for myself. |
+| state_a2_3_q8_self_esteem | TRUE | Text | I definitely feel useless at times. |
+| state_a2_3_q9_self_esteem | TRUE | Text | Sometimes I think I'm no good at all. |

--- a/yal/tests/states_dictionary.md
+++ b/yal/tests/states_dictionary.md
@@ -319,7 +319,7 @@ state_sexual_literacy_assessment_end         |        FALSE       |             
 | state_a1_q9B_sexual_health_lit | TRUE | Text | What's been the MAIN way you or your partner have tried to delay or avoid getting pregnant? |
 |
 
-# A2 Locus of control
+### A2 Locus of control
 | state_name | accepts_user_input | data_type | description |
 | ---------- | ------------------ | --------- | ----------- |
 | state_a2_1_q1_loc_of_ctrl | TRUE | Text | I'm my own boss. |
@@ -328,7 +328,7 @@ state_sexual_literacy_assessment_end         |        FALSE       |             
 | state_a2_1_q4_loc_of_ctrl | TRUE | Text | What I do mainly depends on other people. |
 | state_a2_1_q5_loc_of_ctrl | TRUE | Text | Fate often gets in the way of my plans. |
 
-# A3 Depression and anxiety
+### A3 Depression and anxiety
 | state_name | accepts_user_input | data_type | description |
 | ---------- | ------------------ | --------- | ----------- |
 | state_a3_q1_depression | TRUE | Text | Feeling nervous, anxious or on edge. |
@@ -336,7 +336,15 @@ state_sexual_literacy_assessment_end         |        FALSE       |             
 | state_a3_q3_depression | TRUE | Text | Feeling down, depressed or hopeless |
 | state_a3_q4_depression | TRUE | Text | Not having much interest or pleasure in doing things. |
 
-# A4 Connectedness
+### A4 Connectedness
 | state_name | accepts_user_input | data_type | description |
 | ---------- | ------------------ | --------- | ----------- |
 | state_a4_q1_connectedness | TRUE | Text | Do you have someone to talk to when you have a worry or problem? |
+
+### A5 Gender attitude
+| state_name | accepts_user_input | data_type | description |
+| ---------- | ------------------ | --------- | ----------- |
+| state_a5_q1_gender_attitude | TRUE | Text | There are times when a woman deserves to be beaten. |
+| state_a5_q2_gender_attitude | TRUE | Text | It's a woman's responsibility to avoid getting pregnant. |
+| state_a5_q3_gender_attitude | TRUE | Text | A man and a woman should decide together what type of contraceptive to use |
+| state_a5_q4_gender_attitude | TRUE | Text | If a guy gets women pregnant, the child is the responsibility of both. |

--- a/yal/tests/states_dictionary.md
+++ b/yal/tests/states_dictionary.md
@@ -327,3 +327,11 @@ state_sexual_literacy_assessment_end         |        FALSE       |             
 | state_a2_1_q3_loc_of_ctrl | TRUE | Text | I CAN get relevant health advice if and when I want it. |
 | state_a2_1_q4_loc_of_ctrl | TRUE | Text | What I do mainly depends on other people. |
 | state_a2_1_q5_loc_of_ctrl | TRUE | Text | Fate often gets in the way of my plans. |
+
+# A3 Depression and anxiety
+| state_name | accepts_user_input | data_type | description |
+| ---------- | ------------------ | --------- | ----------- |
+| state_a3_q1_depression | TRUE | Text | Feeling nervous, anxious or on edge. |
+| state_a3_q2_depression | TRUE | Text | Not being able to stop or control worrying. |
+| state_a3_q3_depression | TRUE | Text | Feeling down, depressed or hopeless |
+| state_a3_q4_depression | TRUE | Text | Not having much interest or pleasure in doing things. |

--- a/yal/tests/states_dictionary.md
+++ b/yal/tests/states_dictionary.md
@@ -304,7 +304,7 @@ state_sexual_literacy_assessment_end         |        FALSE       |             
 | state_pushmessage_optin_no                   |        TRUE        |     Text     |            TRUE          | Sends the user confirmation that they will not receive push messages |
 | state_pushmessage_optin_final                |        TRUE        |     Text     |            TRUE          | asks if user would like to go to main menu or aaq |
 
-### Sexual health literacy assessment
+### A1 Sexual health literacy assessment
 | state_name | accepts_user_input | data_type | description |
 | ---------- | ------------------ | --------- | ----------- |
 | state_a1_q1_sexual_health_lit | TRUE | Text | People can reduce the risk of getting STIs by |
@@ -318,3 +318,12 @@ state_sexual_literacy_assessment_end         |        FALSE       |             
 | state_a1_q9A_sexual_health_lit | TRUE | Text | During the last time you had sex, did you or your partner do something or use any method to avoid or delay getting pregnant? |
 | state_a1_q9B_sexual_health_lit | TRUE | Text | What's been the MAIN way you or your partner have tried to delay or avoid getting pregnant? |
 |
+
+# A2 Locus of control
+| state_name | accepts_user_input | data_type | description |
+| ---------- | ------------------ | --------- | ----------- |
+| state_a2_1_q1_loc_of_ctrl | TRUE | Text | I'm my own boss. |
+| state_a2_1_q2_loc_of_ctrl | TRUE | Text | If I work hard, I will be successful. |
+| state_a2_1_q3_loc_of_ctrl | TRUE | Text | I CAN get relevant health advice if and when I want it. |
+| state_a2_1_q4_loc_of_ctrl | TRUE | Text | What I do mainly depends on other people. |
+| state_a2_1_q5_loc_of_ctrl | TRUE | Text | Fate often gets in the way of my plans. |

--- a/yal/tests/states_dictionary.md
+++ b/yal/tests/states_dictionary.md
@@ -304,3 +304,17 @@ state_sexual_literacy_assessment_end         |        FALSE       |             
 | state_pushmessage_optin_no                   |        TRUE        |     Text     |            TRUE          | Sends the user confirmation that they will not receive push messages |
 | state_pushmessage_optin_final                |        TRUE        |     Text     |            TRUE          | asks if user would like to go to main menu or aaq |
 
+### Sexual health literacy assessment
+| state_name | accepts_user_input | data_type | description |
+| ---------- | ------------------ | --------- | ----------- |
+| state_a1_q1_sexual_health_lit | TRUE | Text | People can reduce the risk of getting STIs by |
+| state_a1_q2_sexual_health_lit | TRUE | Text | If Teddy goes out to a restaurant and starts chatting with someone he is sexually attracted to, what is most appropriate way Teddy can tell that person wants to have sex with him? |
+| state_a1_q3_sexual_health_lit | TRUE | Text | Robert has the right to force Samantha to have sex. |
+| state_a1_q4_sexual_health_lit | TRUE | Text | If sexually active, I _am_ able to insist on condoms when I have sex. |
+| state_a1_q5_sexual_health_lit | TRUE | Text | If you are in a relationship, which statement describes you best? |
+| state_a1_q6_sexual_health_lit | TRUE | Text | My sexual needs or desires are important. |
+| state_a1_q7_sexual_health_lit | TRUE | Text | I think it would be important to focus on my own pleasure as well as my partner's during sexual experiences. |
+| state_a1_q8_sexual_health_lit | TRUE | Text | I expect to enjoy sex. |
+| state_a1_q9A_sexual_health_lit | TRUE | Text | During the last time you had sex, did you or your partner do something or use any method to avoid or delay getting pregnant? |
+| state_a1_q9B_sexual_health_lit | TRUE | Text | What's been the MAIN way you or your partner have tried to delay or avoid getting pregnant? |
+|

--- a/yal/tests/states_dictionary.md
+++ b/yal/tests/states_dictionary.md
@@ -335,3 +335,8 @@ state_sexual_literacy_assessment_end         |        FALSE       |             
 | state_a3_q2_depression | TRUE | Text | Not being able to stop or control worrying. |
 | state_a3_q3_depression | TRUE | Text | Feeling down, depressed or hopeless |
 | state_a3_q4_depression | TRUE | Text | Not having much interest or pleasure in doing things. |
+
+# A4 Connectedness
+| state_name | accepts_user_input | data_type | description |
+| ---------- | ------------------ | --------- | ----------- |
+| state_a4_q1_connectedness | TRUE | Text | Do you have someone to talk to when you have a worry or problem? |

--- a/yal/tests/states_dictionary.md
+++ b/yal/tests/states_dictionary.md
@@ -348,3 +348,9 @@ state_sexual_literacy_assessment_end         |        FALSE       |             
 | state_a5_q2_gender_attitude | TRUE | Text | It's a woman's responsibility to avoid getting pregnant. |
 | state_a5_q3_gender_attitude | TRUE | Text | A man and a woman should decide together what type of contraceptive to use |
 | state_a5_q4_gender_attitude | TRUE | Text | If a guy gets women pregnant, the child is the responsibility of both. |
+
+## A6 Body image
+| state_name | accepts_user_input | data_type | description |
+| ---------- | ------------------ | --------- | ----------- |
+| state_a6_q1_body_image | TRUE | Text | I feel good about myself. |
+| state_a6_q2_body_image | TRUE | Text | I feel good about my body. |

--- a/yal/tests/states_dictionary.md
+++ b/yal/tests/states_dictionary.md
@@ -349,8 +349,14 @@ state_sexual_literacy_assessment_end         |        FALSE       |             
 | state_a5_q3_gender_attitude | TRUE | Text | A man and a woman should decide together what type of contraceptive to use |
 | state_a5_q4_gender_attitude | TRUE | Text | If a guy gets women pregnant, the child is the responsibility of both. |
 
-## A6 Body image
+### A6 Body image
 | state_name | accepts_user_input | data_type | description |
 | ---------- | ------------------ | --------- | ----------- |
 | state_a6_q1_body_image | TRUE | Text | I feel good about myself. |
 | state_a6_q2_body_image | TRUE | Text | I feel good about my body. |
+
+### A7 Self-perceived healthcare
+| state_name | accepts_user_input | data_type | description |
+| ---------- | ------------------ | --------- | ----------- |
+| state_a2_2_q5_healthcare | TRUE | Text | When I have health needs (like  contraception or flu symptoms), I go to my closest clinic. |
+| state_a2_2_q6_healthcare | TRUE | Text | How good a job do you feel you are doing in taking care of your health? |

--- a/yal/tests/test_main.py
+++ b/yal/tests/test_main.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from pkgutil import iter_modules
 from unittest import mock
 
 import pytablereader as ptr
@@ -83,6 +84,14 @@ def test_no_state_name_clashes():
 def test_all_states_added_to_docs():
     state_sets = get_state_sets()
     existing_states = set.union(*state_sets) - {"state_name"}
+
+    # States from assessments are dynamic
+    for assessment in iter_modules(["yal/assessment_data"]):
+        module = assessment.module_finder.find_module(assessment.name).load_module()
+        for section in module.ASSESSMENT_QUESTIONS.values():
+            for name, details in section["questions"].items():
+                if details.get("type", "freetext") != "freetext":
+                    existing_states.add(name)
 
     loader = ptr.MarkdownTableFileLoader("yal/tests/states_dictionary.md")
     documented_states = set()

--- a/yal/tests/test_main.py
+++ b/yal/tests/test_main.py
@@ -90,7 +90,7 @@ def test_all_states_added_to_docs():
         module = assessment.module_finder.find_module(assessment.name).load_module()
         for section in module.ASSESSMENT_QUESTIONS.values():
             for name, details in section["questions"].items():
-                if details.get("type", "freetext") != "freetext":
+                if details.get("type", "info") != "info":
                     existing_states.add(name)
 
     loader = ptr.MarkdownTableFileLoader("yal/tests/states_dictionary.md")


### PR DESCRIPTION
- Add states from assessments to documentation check
- Add script for tracking states missing from flow results server
- Add sexual health literacy assessment questions to the data dictionary
- Add locus of control assessment questions to data dictionary
- Add depression and anxiety assessment questions to the data dictionary
- Add connectedness assessment questions to data dictionary
- Add gender attitude assessment questions to data dictionary
- Add body image assessment questions to data dictionary
- Add self perceived healthcare assessment questions to data dictionary
- Add self esteem assessment questions to data dictionary
