### PR TITLE
Fix extra message sent after A1, A2 and A7

### DIFF
--- a/yal/assessment_data/A1_sexual_health_literacy.py
+++ b/yal/assessment_data/A1_sexual_health_literacy.py
@@ -317,19 +317,6 @@ ASSESSMENT_QUESTIONS = {
                     "male_sterilisation": 2,
                     "exclusive_breastfeeding": 1,
                 },
-                "next": "state_a1_final",
-            },
-            "state_a1_final": {
-                "type": "info",
-                "text": "\n".join(
-                    [
-                        "🏁 🎉",
-                        "",
-                        "Awesome. That's all the questions for now!",
-                        "",
-                        "[persona_emoji] Thanks for being so patient and honest 😌.",
-                    ]
-                ),
                 "next": None,
             },
         },

--- a/yal/assessment_data/A1_sexual_health_literacy.py
+++ b/yal/assessment_data/A1_sexual_health_literacy.py
@@ -122,7 +122,7 @@ ASSESSMENT_QUESTIONS = {
                     ("not_sure", "Not sure"),
                     ("disagree", "Disagree"),
                     ("strongly_disagree", "Strongly disagree"),
-                    ("not_active", "I am not sexually active"),
+                    ("not_active", "Not sexually active"),
                 ],
                 "scoring": {
                     "strongly_agree": 5,

--- a/yal/assessment_data/A2_locus_of_control.py
+++ b/yal/assessment_data/A2_locus_of_control.py
@@ -85,7 +85,7 @@ ASSESSMENT_QUESTIONS = {
                     "Extremely True",
                 ],
                 "next": None,
-            }
+            },
         },
     },
 }

--- a/yal/assessment_data/A2_locus_of_control.py
+++ b/yal/assessment_data/A2_locus_of_control.py
@@ -84,20 +84,8 @@ ASSESSMENT_QUESTIONS = {
                     "Very true",
                     "Extremely True",
                 ],
-                "next": "state_a2_1_final",
-            },
-            "state_a2_1_final": {
-                "type": "info",
-                "text": "\n".join(
-                    [
-                        "[persona_emoji] Thanks, that was great! "
-                        "And what about your health...?",
-                        "",
-                        "That's all for now",
-                    ]
-                ),
                 "next": None,
-            },
+            }
         },
     },
 }

--- a/yal/assessment_data/A7_self_perceived_healthcare.py
+++ b/yal/assessment_data/A7_self_perceived_healthcare.py
@@ -47,17 +47,6 @@ ASSESSMENT_QUESTIONS = {
                     "ok": 2,
                     "pretty_bad": 1,
                 },
-                "next": "state_a2_2_q7_healthcare",
-            },
-            "state_a2_2_final": {
-                "type": "info",
-                "text": "\n".join(
-                    [
-                        "[persona_emoji]  Fantastic! That's it.",
-                        "",
-                        "I'll chat with you again tomorrow.",
-                    ]
-                ),
                 "next": None,
             },
         },


### PR DESCRIPTION
A1 and A7 had final messages in the assessment data that are now duplicated in the final states
A2 has a message that was deleted from the miroboard
Shorten an item in the sexual lit assessment options