### PR TITLE
change keyword for round 2 ads for instagram paid ad from love2bwise to talk2bwise

### DIFF
--- a/yal/main.py
+++ b/yal/main.py
@@ -45,7 +45,7 @@ TRACKING_KEYWORDS = {
 }
 TRACKING_KEYWORDS_ROUND_2 = {
     "chat2bwise",
-    "love2bwise",
+    "talk2bwise",
     "hi",
     "click2bwise",
     "want2bwise",


### PR DESCRIPTION
Avert was not happy with the keyword for round 2 of the ads