### PR TITLE
Rename assessment_name contact field to assessment_reminder_name

### DIFF
--- a/yal/assessments.py
+++ b/yal/assessments.py
@@ -201,7 +201,7 @@ class Application(BaseApplication):
 
         data = {
             "assessment_reminder": reminder_time.isoformat(),
-            "assessment_name": assessment_name,
+            "assessment_reminder_name": assessment_name,
         }
 
         await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)

--- a/yal/docs/contact_fields.md
+++ b/yal/docs/contact_fields.md
@@ -11,7 +11,7 @@ Fields
 | Field name                                 | use                                                                                                     |
 |--------------------------------------------|---------------------------------------------------------------------------------------------------------|
 | assessment_reminder                        | Set a time to remind the user to take an assessment that they haven't started                           |
-| assessment_name                            | Name of the assessment we need to remind the user to take                                               |
+| assessment_reminder_name                   | Name of the assessment we need to remind the user to take                                               |
 | sexual_health_lit_risk                     | save the risk status from sexual_health_lit assessment (high_risk or low_risk)                          |
 | sexual_health_lit_score                    | save the score from sexual_health_lit assessment                                                        |
 | depression_and_anxiety_risk                | save the risk status from depression and anxiety assessment (high_risk or low_risk)                     |

--- a/yal/tests/test_onboarding.py
+++ b/yal/tests/test_onboarding.py
@@ -467,7 +467,7 @@ async def test_assessment_skip(get_current_datetime, tester: AppTester, rapidpro
     assert json.loads(request.body.decode("utf-8")) == {
         "fields": {
             "assessment_reminder": "2022-06-20T16:30:00",
-            "assessment_name": "sexual_health_literacy",
+            "assessment_reminder_name": "sexual_health_literacy",
         },
     }
 


### PR DESCRIPTION
Having it be assessment_name overwrites the metadata field that we're using to keep state in the assessments, so we can't use it as a contact field name, so I've renamed it to fix that
