### PR TITLE
YAL: ensure parent id is added to topics viewed

### DIFF
--- a/yal/mainmenu.py
+++ b/yal/mainmenu.py
@@ -362,7 +362,6 @@ class Application(BaseApplication):
             "feature_redirects", page_details.get("feature_redirects", [])
         )
 
-
         # If a user loads a content repo page from somewhere other than the main menu
         # then we need to infer the menu level and the topics they've seen
         inferred_menu_level = len(page_details["title"].split("/")) - 1

--- a/yal/mainmenu.py
+++ b/yal/mainmenu.py
@@ -362,9 +362,13 @@ class Application(BaseApplication):
             "feature_redirects", page_details.get("feature_redirects", [])
         )
 
+
         # If a user loads a content repo page from somewhere other than the main menu
-        # then we need to infer the menu level
+        # then we need to infer the menu level and the topics they've seen
         inferred_menu_level = len(page_details["title"].split("/")) - 1
+
+        if not metadata.get("suggested_content") and not metadata.get("topics_viewed"):
+            self.save_metadata("topics_viewed", [str(page_details["parent_id"])])
 
         # do not increment menu level when retrieving the next whatsapp message,
         # only when going to a child page in content repo

--- a/yal/tests/test_main.py
+++ b/yal/tests/test_main.py
@@ -503,7 +503,7 @@ async def test_push_message_buttons_to_display_page(
             ]
         )
     )
-
+    tester.assert_metadata("topics_viewed", ["123"])
     assert len(rapidpro_mock.tstate.requests) == 4
     assert len(contentrepo_api_mock.tstate.requests) == 2
 


### PR DESCRIPTION
If we query the content repo with an empty `topics_viewed` parameter it raises a 500 error. so we should always make sure this is set when we're loading a page when we don't have suggested content.