### PR TITLE
Feature/yal 602 handle phase 2 invite responses

### DIFF
--- a/yal/onboarding.py
+++ b/yal/onboarding.py
@@ -377,3 +377,18 @@ class Application(BaseApplication):
 
         if inbound == "remind me later":
             return await self.go_to_state("state_reschedule_onboarding_reminders")
+
+    async def state_phase2_update_exising_user_profile(self):
+        # save the other fields that are usually collected in onboarding
+        self.save_answer("state_persona_name", self.user.metadata.get("persona_name"))
+        self.save_answer("state_persona_emoji", self.user.metadata.get("persona_emoji"))
+        self.save_answer("state_age", self.user.metadata.get("age"))
+
+        # send the user to state_gender if their gender isn't set
+        gender = self.user.metadata.get("gender")
+        if not gender or gender == "" or gender.lower() == "skip":
+            return await self.go_to_state("state_gender")
+
+        # if the user's gender is set, save it and send them to state_rel_status
+        self.save_answer("state_gender", gender)
+        return await self.go_to_state("state_rel_status")

--- a/yal/tests/states_dictionary.md
+++ b/yal/tests/states_dictionary.md
@@ -142,6 +142,7 @@
 | state_locus_of_control_assessment_start     |        FALSE       |              |            FALSE         | Explains to the user what is going to happen next                                                                   |
 | state_locus_of_control_assessment_few_qs    |        TRUE        |     Text     |            TRUE          | User responds "ok" when they start the assessment  |
 | state_locus_of_control_assessment_end |        FALSE       |              |            FALSE         | User has completed the assessment and receives the end message |
+| state_phase2_update_exising_user_profile |        FALSE       |              |            FALSE         | For phase 2 we need to send existing users back to onboarding so that they can take the assessments. This state handles the push message response and inserts them based on their profile (if their gender isn't set they go to state_gender, if it is set they go to state_rel_status) |
 
 
 ### OptOut flow

--- a/yal/tests/test_main.py
+++ b/yal/tests/test_main.py
@@ -795,3 +795,24 @@ async def test_self_perceived_healthcare_assessment(tester: AppTester):
     tester.assert_metadata(
         "assessment_end_state", "state_self_perceived_healthcare_assessment_end"
     )
+
+
+@pytest.mark.asyncio
+async def test_mainmenu_payload(tester: AppTester, rapidpro_mock, contentrepo_api_mock):
+    """
+    If there's a button payload that indicates that the user should be shown the main menu,
+    then we should send them there
+    """
+    await tester.user_input(
+        "test",
+        transport_metadata={
+            "message": {
+                "button": {"payload": "state_pre_mainmenu"}
+            }
+        },
+    )
+    tester.assert_state("state_mainmenu")
+    tester.assert_num_messages(2)
+
+    assert len(rapidpro_mock.tstate.requests) == 3
+    assert len(contentrepo_api_mock.tstate.requests) == 5

--- a/yal/tests/test_main.py
+++ b/yal/tests/test_main.py
@@ -800,19 +800,58 @@ async def test_self_perceived_healthcare_assessment(tester: AppTester):
 @pytest.mark.asyncio
 async def test_mainmenu_payload(tester: AppTester, rapidpro_mock, contentrepo_api_mock):
     """
-    If there's a button payload that indicates that the user should be shown the main menu,
-    then we should send them there
+    If there's a button payload that indicates that the user should be shown the main
+    menu, then we should send them there
     """
     await tester.user_input(
         "test",
-        transport_metadata={
-            "message": {
-                "button": {"payload": "state_pre_mainmenu"}
-            }
-        },
+        transport_metadata={"message": {"button": {"payload": "state_pre_mainmenu"}}},
     )
     tester.assert_state("state_mainmenu")
     tester.assert_num_messages(2)
 
     assert len(rapidpro_mock.tstate.requests) == 3
     assert len(contentrepo_api_mock.tstate.requests) == 5
+
+
+@pytest.mark.asyncio
+async def test_phase2_payload_message_directs_to_onboarding_gender(
+    tester: AppTester, rapidpro_mock
+):
+    """
+    If there's a button payload that indicates the user is responding to the phase2
+    invite, then we should send them to the onboarding state that handles that
+    """
+    await tester.user_input(
+        "test",
+        transport_metadata={
+            "message": {
+                "button": {"payload": "state_phase2_update_exising_user_profile"}
+            }
+        },
+    )
+    tester.assert_state("state_gender")
+
+    assert len(rapidpro_mock.tstate.requests) == 2
+
+
+@pytest.mark.asyncio
+async def test_phase2_payload_message_directs_to_onboarding_rel_status(
+    tester: AppTester, rapidpro_mock
+):
+    """
+    If there's a button payload that indicates the user is responding to the phase2
+    invite, then we should send them to the onboarding state that handles that
+    """
+    rapidpro_mock.tstate.contact_fields["gender"] = "male"
+    await tester.user_input(
+        "test",
+        transport_metadata={
+            "message": {
+                "button": {"payload": "state_phase2_update_exising_user_profile"}
+            }
+        },
+    )
+    tester.assert_state("state_rel_status")
+
+    assert len(rapidpro_mock.tstate.requests) == 2


### PR DESCRIPTION
We are sending existing users a push message to inform them that there is new content and that they should update their profile. When they respond to that push message we want to insert them into the onboarding flow so that they are prompted to start the assessments and opt in to messages.
This PR is to catch the push message and handle that insertion into the onboarding flow

Design [here](https://miro.com/app/board/uXjVP-lrlK0=/?moveToWidget=3458764541091752748&cot=14)