### PR TITLE
YAL: use default page for related content if we're responding to a push

### DIFF
--- a/yal/mainmenu.py
+++ b/yal/mainmenu.py
@@ -520,6 +520,7 @@ class Application(BaseApplication):
         self.save_metadata(
             "suggested_choices", [str(i + k) for k in range(len(suggested_choices))]
         )
+
         error = await self.update_suggested_content_details("main", suggested_text)
         if error:
             return await self.go_to_state("state_error")


### PR DESCRIPTION
Related to this PR https://github.com/praekeltfoundation/vaccine-eligibility/commit/9668b4b32369da40c8d18430352a46e732b65097
~~if we're following a push message then the suggested content isn't set and they haven't viewed any topics yet. Use a default so that the service messages don't keep breaking~~

~~`topics_viewed` is only used for the suggested content and that isn't in use at the moment~~

We shouldn't break if we weren't able to get suggested content.