### PR TITLE
Suggested content api calls are logging errors in sentry when we make…

### DIFF
--- a/yal/contentrepo.py
+++ b/yal/contentrepo.py
@@ -85,7 +85,7 @@ async def get_choices_by_path(path: str) -> Tuple[bool, List[Choice]]:
                 break
             except HTTP_EXCEPTIONS as e:
                 if i == 2:
-                    logger.exception(e)
+                    logger.warning(e)
                     return True, []
                 else:
                     continue

--- a/yal/contentrepo.py
+++ b/yal/contentrepo.py
@@ -84,6 +84,8 @@ async def get_choices_by_path(path: str) -> Tuple[bool, List[Choice]]:
 
                 break
             except HTTP_EXCEPTIONS as e:
+                # TODO: better error handling once contentrepo is updated to
+                # return 404 errors on page not found
                 if i == 2:
                     logger.warning(e)
                     return True, []

--- a/yal/mainmenu.py
+++ b/yal/mainmenu.py
@@ -44,9 +44,13 @@ class Application(BaseApplication):
                     "topics_viewed", list(parent_topic_links.values())[:1]
                 )
             )
-            error, suggested_choices = await contentrepo.get_suggested_choices(
-                topics_viewed
-            )
+            if topics_viewed:
+                error, suggested_choices = await contentrepo.get_suggested_choices(
+                    topics_viewed
+                )
+            else:
+                return {}
+
             if error:
                 return {}
             self.save_metadata(

--- a/yal/tests/test_main.py
+++ b/yal/tests/test_main.py
@@ -271,7 +271,7 @@ async def test_reset_keyword(tester: AppTester, rapidpro_mock, contentrepo_api_m
     tester.assert_num_messages(2)
 
     assert len(rapidpro_mock.tstate.requests) == 3
-    assert len(contentrepo_api_mock.tstate.requests) == 5
+    assert len(contentrepo_api_mock.tstate.requests) == 4
 
 
 @pytest.mark.asyncio
@@ -387,7 +387,7 @@ async def test_state_start_to_mainmenu(
     tester.assert_num_messages(2)
 
     assert len(rapidpro_mock.tstate.requests) == 3
-    assert len(contentrepo_api_mock.tstate.requests) == 5
+    assert len(contentrepo_api_mock.tstate.requests) == 4
 
     tester.assert_metadata("longitude", "28.0251783")
     tester.assert_metadata("latitude", "-26.2031026")
@@ -876,7 +876,7 @@ async def test_mainmenu_payload(tester: AppTester, rapidpro_mock, contentrepo_ap
     tester.assert_num_messages(2)
 
     assert len(rapidpro_mock.tstate.requests) == 3
-    assert len(contentrepo_api_mock.tstate.requests) == 5
+    assert len(contentrepo_api_mock.tstate.requests) == 4
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
… invalid requests

The api call wont be made when the topics_viewed is empty
The error wont be logged as an exception, only as a warning, when the page_id is that of a content page index. This needs to still be updated in contentrepo for better error handling

there is one other place where this takes place, but this needs further discussion