### PR TITLE
Fix content titles for related pages

### DIFF
--- a/yal/tests/test_mainmenu.py
+++ b/yal/tests/test_mainmenu.py
@@ -1677,7 +1677,7 @@ async def test_state_content_page_related(
                 "",
                 "Message test content 2",
                 "",
-                "1. Related Content 2",
+                "1. Related Content",
                 "",
                 "-----",
                 "*Or reply:*",


### PR DESCRIPTION
Before, we used the titles returned from ContentRepo in the
"related_pages" key. The issue with this is because we're requesting
"whatsapp=true", we're getting the whatsapp titles, not the content
titles.

In this case we want the content titles instead, since the WhatsApp
titles include breadcrumbs, and those are too long for interactive
buttons on WhatsApp.
