### PR TITLE
Ensure LoC assessment reminder is scheduled

### DIFF
--- a/yal/onboarding.py
+++ b/yal/onboarding.py
@@ -263,6 +263,11 @@ class Application(BaseApplication):
             "onboarding_reminder_type": "",
             "country": "south africa" if country == "yes" else "",
             "used_bot_before": self.user.answers.get("state_seen_before"),
+            # Since the next step is the loc assessment, just set reminder details now
+            "assessment_reminder_sent": "",
+            "assessment_reminder": get_current_datetime().isoformat(),
+            "assessment_reminder_name": "locus_of_control",
+            "assessment_reminder_type": "reengagement 30min",
         }
 
         error = await rapidpro.update_profile(whatsapp_id, data, self.user.metadata)
@@ -272,7 +277,6 @@ class Application(BaseApplication):
         return await self.go_to_state("state_locus_of_control_assessment_start")
 
     async def state_locus_of_control_assessment_start(self):
-        # TODO: add timeout and reminders to complete assessments
         msg = self._(
             "\n".join(
                 [

--- a/yal/tests/test_onboarding.py
+++ b/yal/tests/test_onboarding.py
@@ -390,7 +390,11 @@ async def test_state_seen_before(
 
 
 @pytest.mark.asyncio
-async def test_submit_onboarding(tester: AppTester, rapidpro_mock):
+@mock.patch("yal.onboarding.get_current_datetime")
+async def test_submit_onboarding(
+    get_current_datetime, tester: AppTester, rapidpro_mock
+):
+    get_current_datetime.return_value = datetime(2022, 6, 19, 17, 30)
     tester.setup_state("state_seen_before")
     tester.setup_answer("state_age", "22")
     tester.setup_answer("state_gender", "other")
@@ -427,6 +431,10 @@ async def test_submit_onboarding(tester: AppTester, rapidpro_mock):
             "persona_emoji": "⛑️",
             "country": "south africa",
             "used_bot_before": "yes",
+            "assessment_reminder_sent": "",
+            "assessment_reminder": "2022-06-19T17:30:00",
+            "assessment_reminder_name": "locus_of_control",
+            "assessment_reminder_type": "reengagement 30min",
         },
     }
 


### PR DESCRIPTION
Currently, when a user is offered the LoC assessment during onboarding but they don't respond to it, they don't get a reminder.
These fields need to be set when they are offered the assessment so that the reminder is sent