### PR TITLE
YAL: fix i'm not interested reminder response

### DIFF
--- a/yal/main.py
+++ b/yal/main.py
@@ -74,7 +74,7 @@ ASSESSMENT_REENGAGEMENT_KEYWORDS = {
     "not interested",
     "skip",
     "remind me tomorrow",
-    "I m not interested",
+    "i m not interested",
 }
 SURVEY_KEYWORDS = {"baseline"}
 CALLBACK_CHECK_KEYWORDS = {"callback"}

--- a/yal/tests/test_assessments.py
+++ b/yal/tests/test_assessments.py
@@ -410,14 +410,9 @@ async def test_state_handle_assessment_reminder_response_loc_tomorrow_again(
 async def test_state_handle_assessment_reminder_response_not_interested(
     tester: AppTester, contentrepo_api_mock
 ):
-    tester.user.metadata["assessment_reminder_name"] = "locus_of_control"
     tester.user.metadata["assessment_reminder_sent"] = "True"
-    tester.user.metadata["assessment_reminder_type"] = "reengagement 30min"
-
-    tester.setup_state("state_handle_assessment_reminder_response")
-    await tester.user_input(
-        session=Message.SESSION_EVENT.NEW, content="I'm not interested"
-    )
+    tester.setup_state("state_survey_question")
+    await tester.user_input("I'm not interested")
     tester.assert_state("state_mainmenu")
 
 


### PR DESCRIPTION
Use lowercase for I'm not interested keyword and make the test more accurate so that it picks this up