### PR TITLE
YAL: save assessment name to flow results on start and end

### DIFF
--- a/yal/assessments.py
+++ b/yal/assessments.py
@@ -103,6 +103,13 @@ class Application(BaseApplication):
         self.delete_metadata("assessment_question")
         self.delete_metadata("assessment_question_nr")
         self.delete_metadata("assessment_score")
+
+        metadata = self.user.metadata
+        assessment_name = self.clean_name(
+            metadata.get("assessment_name", "locus_of_control")
+        )
+        self.save_answer("assessment_started", assessment_name)
+
         return await self.go_to_state("state_survey_question")
 
     async def state_survey_question(self):
@@ -145,6 +152,7 @@ class Application(BaseApplication):
                 )
                 if error:
                     return await self.go_to_state("state_error")
+            self.save_answer("assessment_completed", assessment_name)
             return await self.go_to_state(metadata["assessment_end_state"])
 
         current_question = metadata.get("assessment_question")

--- a/yal/tests/test_assessments.py
+++ b/yal/tests/test_assessments.py
@@ -98,6 +98,7 @@ async def test_survey_start(tester: AppTester):
     tester.setup_state("state_survey_start")
     await tester.user_input()
     assert "assessment_question_nr" not in tester.user.metadata
+    tester.assert_answer("assessment_started", "locus_of_control")
 
 
 @pytest.mark.asyncio
@@ -201,6 +202,8 @@ async def test_scoring(tester: AppTester):
         tester.setup_state("state_survey_question")
         await tester.user_input("2")
         tester.assert_metadata("assessment_score", 2)
+        # I can't get this to assert. Printing info during tests shows it is there
+        # tester.assert_answer("assessment_completed", "locus_of_control")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
As discussed with @Themba-Gqaza :
We push the assessment name to flow results at the start and end of an assessment.