### PR TITLE
send correct message after invite not interested 

### DIFF
--- a/yal/assessments.py
+++ b/yal/assessments.py
@@ -144,6 +144,7 @@ class Application(BaseApplication):
     LATER_STATE = "state_assessment_later_submit"
     REMINDER_STATE = "state_handle_assessment_reminder_response"
     REMINDER_NOT_INTERESTED_STATE = "state_reminder_not_interested"
+    NOT_INTERESTED_STATE = "state_not_interested"
 
     def clean_name(self, name):
         return name.removeprefix("state_").removesuffix("_assessment")

--- a/yal/main.py
+++ b/yal/main.py
@@ -145,7 +145,6 @@ class Application(
             )
 
             endline_survey_started = self.user.metadata.get("endline_survey_started")
-            endline_reminder = self.user.metadata.get("endline_reminder")
             feedback_state = await self.get_feedback_state()
             payload = utils.get_by_path(
                 message.transport_metadata, "message", "button", "payload"
@@ -232,21 +231,7 @@ class Application(
                 if keyword == "remind me tomorrow":
                     self.state_name = AssessmentApplication.REMINDER_STATE
                 elif keyword == "i m not interested":
-                    if endline_reminder:
-                        self.state_name = (
-                            AssessmentApplication.REMINDER_NOT_INTERESTED_STATE
-                        )
-                    else:
-                        self.state_name = EndlineTermsApplication.NO_CONSENT_STATE
-
-                        data = {
-                            "endline_survey_started": "not_interested",
-                        }
-                        error = await rapidpro.update_profile(
-                            whatsapp_id, data, self.user.metadata
-                        )
-                        if error:
-                            return await self.go_to_state("state_error")
+                    self.state_name = AssessmentApplication.NOT_INTERESTED_STATE
                 else:
                     self.state_name = EndlineTermsApplication.START_STATE
 

--- a/yal/tests/surveys/test_endline.py
+++ b/yal/tests/surveys/test_endline.py
@@ -149,36 +149,7 @@ async def test_endline_invitation_not_interested(
 
     [reply] = await app.process_message(msg)
 
-    assert user.state.name == "state_no_consent"
-
-
-@pytest.mark.asyncio
-async def test_endline_reminder_not_interested(
-    tester: AppTester,
-    rapidpro_mock,
-):
-    user = User(
-        addr="278201234567",
-        state=StateData(),
-        session_id=1,
-        metadata={
-            "baseline_survey_completed": True,
-            "endline_reminder": True,
-            "endline_survey_started": "Pending",
-        },
-    )
-    app = Application(user)
-    msg = Message(
-        content="I'm not interested",
-        to_addr="27820001002",
-        from_addr="27820001003",
-        transport_name="whatsapp",
-        transport_type=Message.TRANSPORT_TYPE.HTTP_API,
-    )
-
-    [reply] = await app.process_message(msg)
-
-    assert user.state.name == "state_reminder_not_interested"
+    assert user.state.name == "state_not_interested"
 
 
 @pytest.mark.asyncio

--- a/yal/tests/test_main.py
+++ b/yal/tests/test_main.py
@@ -874,20 +874,6 @@ async def test_endline_remind_me_tomorrow_keywords(
 
 
 @pytest.mark.asyncio
-async def test_endline_survey_not_interested_reminder_keywords(
-    tester: AppTester, rapidpro_mock, contentrepo_api_mock
-):
-    rapidpro_mock.tstate.contact_fields["onboarding_completed"] = True
-    rapidpro_mock.tstate.contact_fields["terms_accepted"] = True
-    rapidpro_mock.tstate.contact_fields["baseline_survey_completed"] = True
-    rapidpro_mock.tstate.contact_fields["endline_survey_completed"] = False
-    rapidpro_mock.tstate.contact_fields["endline_reminder"] = True
-
-    await tester.user_input("I'm not interested")
-    tester.assert_state("state_reminder_not_interested")
-
-
-@pytest.mark.asyncio
 async def test_endline_survey_not_interested_keywords(
     tester: AppTester, rapidpro_mock, contentrepo_api_mock
 ):
@@ -897,7 +883,7 @@ async def test_endline_survey_not_interested_keywords(
     rapidpro_mock.tstate.contact_fields["endline_survey_completed"] = False
 
     await tester.user_input("I'm not interested")
-    tester.assert_state("state_no_consent")
+    tester.assert_state("state_not_interested")
 
     tester.assert_metadata("endline_survey_started", "not_interested")
 


### PR DESCRIPTION
Removing unnecessary if statement, the endline reminder for not interested is handles in the re-engagenent and assessment reminder sent if statement