### PR TITLE
Remove vaccine registration entry point for decommissioning

### DIFF
--- a/vaccine/healthcheck_vacreg_ussd.py
+++ b/vaccine/healthcheck_vacreg_ussd.py
@@ -9,6 +9,11 @@ from vaccine.vaccine_reg_ussd import Application as VacRegApp
 
 
 class Application(VacRegApp, HealthCheckApp):
+    """
+    Note: The Vaccine Registration option (VacRegApp.START_STATE) has been decommissioned and 
+    removed as a menu choice as of March 2025. The menu now primarily offers the HealthCheck Symptom Checker 
+    and language selection.
+    """
     START_STATE = "state_language"
 
     async def state_menu(self):
@@ -44,7 +49,6 @@ class Application(VacRegApp, HealthCheckApp):
             ),
             error=self._("ERROR: Please try again"),
             choices=[
-                Choice(VacRegApp.START_STATE, self._("Vaccine Registration")),
                 Choice(
                     HealthCheckApp.START_STATE,
                     self._("HealthCheck Symptom checker [ENG]"),

--- a/vaccine/tests/test_healthcheck_vacreg_ussd.py
+++ b/vaccine/tests/test_healthcheck_vacreg_ussd.py
@@ -430,7 +430,7 @@ async def test_state_timed_out_timed_out():
 async def test_state_language():
     tester = AppTester(Application)
     tester.setup_state("state_menu")
-    await tester.user_input("3")
+    await tester.user_input("2")
     tester.assert_state("state_language")
 
     await tester.user_input("2")


### PR DESCRIPTION
This removes vaccine registration as a menu option so there's no entry point to the app since it's being de-commissioned. 