### PR TITLE
Set buildkit to true in workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,3 +38,4 @@ jobs:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          buildkit: true


### PR DESCRIPTION
This change ensures that Buildkit is enabled in the remote workflow. 